### PR TITLE
zigbee ct: Use system properties to refer to the xml files

### DIFF
--- a/org.osgi.impl.service.zigbee/src/org/osgi/impl/service/zigbee/basedriver/configuration/ConfigurationFileReader.java
+++ b/org.osgi.impl.service.zigbee/src/org/osgi/impl/service/zigbee/basedriver/configuration/ConfigurationFileReader.java
@@ -77,6 +77,8 @@ public class ConfigurationFileReader {
 		return instance;
 	}
 
+	private static final String		zclFilename			= System.getProperty("org.osgi.impl.service.zigbee.zcl", "zcl.xml");
+
 	/**
 	 * Parse the input stream passed as parameter. The input stream refers to
 	 * the xml file that contains the node configuratiosn.
@@ -86,7 +88,7 @@ public class ConfigurationFileReader {
 
 	private void readXmlFile(InputStream is) throws Exception {
 
-		profiles = ZigBeeProfiles.getInstance(new FileInputStream("zcl.xml"));
+		profiles = ZigBeeProfiles.getInstance(new FileInputStream(zclFilename));
 
 		DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
 		DocumentBuilder dBuilder;

--- a/org.osgi.impl.service.zigbee/src/org/osgi/impl/service/zigbee/util/teststep/TestStepForZigBeeImpl.java
+++ b/org.osgi.impl.service.zigbee/src/org/osgi/impl/service/zigbee/util/teststep/TestStepForZigBeeImpl.java
@@ -35,7 +35,7 @@ public class TestStepForZigBeeImpl implements TestStep {
 	static public final String	ACTIVATE_ZIGBEE_DEVICES	= "activate_devices";
 	public static final String	EVENT_REPORTABLE		= "event_reportable";
 
-	private static final String	configFilePath			= "zigbee-ct-template.xml";
+	private static final String	configFilePath			= System.getProperty("org.osgi.test.cases.zigbee.template", "zigbee-ct-template.xml");
 
 	private ZigBeeBaseDriver	baseDriver;
 

--- a/org.osgi.test.cases.zigbee/bnd.bnd
+++ b/org.osgi.test.cases.zigbee/bnd.bnd
@@ -41,6 +41,8 @@ Test-Cases			= ${testcases}
 
 -runproperties = ${runproperties}, \
     comm.rxtx.disable=true, \
+	org.osgi.test.cases.zigbee.template=${.}/zigbee-ct-template.xml, \
+	org.osgi.impl.service.zigbee.zcl=${.}/zcl.xml, \
 	org.osgi.service.zigbee.host.path=:testcase:, \
 	org.osgi.service.zigbee.loglevel.debug=true, \
 	org.osgi.service.zigbee.loglevel.warn=true, \

--- a/org.osgi.test.cases.zigbee/src/org/osgi/test/cases/zigbee/TestStepLauncher.java
+++ b/org.osgi.test.cases.zigbee/src/org/osgi/test/cases/zigbee/TestStepLauncher.java
@@ -46,7 +46,7 @@ public class TestStepLauncher {
 	 */
 	public static final String		EVENT_REPORTABLE		= "event_reportable";
 
-	private static final String		configFilename			= "zigbee-ct-template.xml";
+	private static final String		configFilename			= System.getProperty("org.osgi.test.cases.zigbee.template", "zigbee-ct-template.xml");
 
 	private ConfigurationFileReader	confReader;
 	private static TestStepProxy	tproxy;

--- a/org.osgi.test.cases.zigbee/src/org/osgi/test/cases/zigbee/config/file/ConfigurationFileReader.java
+++ b/org.osgi.test.cases.zigbee/src/org/osgi/test/cases/zigbee/config/file/ConfigurationFileReader.java
@@ -81,10 +81,11 @@ public class ConfigurationFileReader {
 		}
 		return instance;
 	}
+	private static final String		zclFilename			= System.getProperty("org.osgi.impl.service.zigbee.zcl", "zcl.xml");
 
 	private void readXmlFile(InputStream is) throws Exception {
 
-		this.profiles = ZigBeeProfiles.getInstance(new FileInputStream("zcl.xml"));
+		this.profiles = ZigBeeProfiles.getInstance(new FileInputStream(zclFilename));
 
 		DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
 		DocumentBuilder dBuilder;


### PR DESCRIPTION
The ZigBee CT needs to run outside of the build repo. So we use system
properties in -runproperties which the CT packages will properly
handle by copying the referenced resources into the packaged CT.