### PR TITLE
spec: Use new github issues URL for spec feedback

### DIFF
--- a/osgi.specs/docbook/license/distribution.feedback.license.2.0.xml
+++ b/osgi.specs/docbook/license/distribution.feedback.license.2.0.xml
@@ -130,6 +130,6 @@
 
     <para>Comments about this specification can be raised at:</para>
 
-    <para><code><link xlink:href="https://osgi.org/bugzilla/"/></code></para>
+    <para><code><link xlink:href="https://github.com/osgi/design/issues"/></code></para>
   </section>
 </preface>

--- a/osgi.specs/docbook/license/osgi.specification.license.2.0.xml
+++ b/osgi.specs/docbook/license/osgi.specification.license.2.0.xml
@@ -107,6 +107,6 @@
 
     <para>Comments about this specification can be raised at:</para>
 
-    <para><code><link xlink:href="https://osgi.org/bugzilla/"/></code></para>
+    <para><code><link xlink:href="https://github.com/osgi/design/issues"/></code></para>
   </section>
 </preface>


### PR DESCRIPTION
The public bugzilla installation is shutdown.