### PR TITLE
Shutdown frameworks started in testMultipBSNVersion

### DIFF
--- a/org.osgi.test.cases.framework.launch/src/org/osgi/test/cases/framework/launch/junit/FrameworkLaunchTests.java
+++ b/org.osgi.test.cases.framework.launch/src/org/osgi/test/cases/framework/launch/junit/FrameworkLaunchTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) OSGi Alliance (2009, 2019). All Rights Reserved.
+ * Copyright (c) OSGi Alliance (2009, 2020). All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -492,6 +492,7 @@ public class FrameworkLaunchTests extends LaunchTest {
 			assertEquals("Wrong exception type.", BundleException.DUPLICATE_BUNDLE_ERROR, e.getType());
 			// expected
 		}
+		stopFramework(frameworkSingleBSN1);
 
 		// explicitly set bsnversion to single
 		Map<String, String> configurationSingle2 = getConfiguration(getName()
@@ -507,6 +508,7 @@ public class FrameworkLaunchTests extends LaunchTest {
 			assertEquals("Wrong exception type.", BundleException.DUPLICATE_BUNDLE_ERROR, e.getType());
 			// expected
 		}
+		stopFramework(frameworkSingleBSN2);
 	}
 
 	public void testUUID() {


### PR DESCRIPTION
This test starts three instances of a Framework, but only stops one of
them.  This leaves two instances up for the remainder of the test.
Stopping each framework to ensure all resources associated with the test
can be cleaned up.