### PR TITLE
Add system refreshed event to javadoc on waitForStop

### DIFF
--- a/org.osgi.framework/src/org/osgi/framework/FrameworkEvent.java
+++ b/org.osgi.framework/src/org/osgi/framework/FrameworkEvent.java
@@ -173,9 +173,9 @@ public class FrameworkEvent extends EventObject {
 	 * The Framework has stopped and the framework requires a new class loader
 	 * to restart.
 	 * <p>
-	 * This event is fired when the Framework has been stopped because of a stop
-	 * operation on the system bundle and the framework requires a new class
-	 * loader to be used to restart. For example, if a framework extension
+	 * This event is fired when the Framework has been stopped because of a
+	 * refresh operation on the system bundle and the framework requires a new
+	 * class loader to be used to restart. For example, if a framework extension
 	 * bundle has been refreshed. The source of this event is the System Bundle.
 	 * 
 	 * @since 1.9

--- a/org.osgi.framework/src/org/osgi/framework/launch/Framework.java
+++ b/org.osgi.framework/src/org/osgi/framework/launch/Framework.java
@@ -118,31 +118,33 @@ public interface Framework extends Bundle {
 	 * A Framework Event is returned to indicate why this Framework has stopped.
 	 * 
 	 * @param timeout Maximum number of milliseconds to wait until this
-	 *        Framework has completely stopped. A value of zero will wait
-	 *        indefinitely.
+	 *            Framework has completely stopped. A value of zero will wait
+	 *            indefinitely.
 	 * @return A Framework Event indicating the reason this method returned. The
 	 *         following {@code FrameworkEvent} types may be returned by this
 	 *         method.
 	 *         <ul>
 	 *         <li>{@link FrameworkEvent#STOPPED STOPPED} - This Framework has
-	 *         been stopped. </li>
-	 * 
+	 *         been stopped.</li>
 	 *         <li>{@link FrameworkEvent#STOPPED_UPDATE STOPPED_UPDATE} - This
 	 *         Framework has been updated which has shutdown and will now
 	 *         restart.</li>
-	 * 
+	 *         <li>{@link FrameworkEvent#STOPPED_SYSTEM_REFRESHED
+	 *         STOPPED_SYSTEM_REFRESHED} - The Framework has been stopped
+	 *         because of a refresh operation on the system bundle. A new class
+	 *         loader must be used to restart the Framework.</li>
 	 *         <li>{@link FrameworkEvent#ERROR ERROR} - The Framework
 	 *         encountered an error while shutting down or an error has occurred
-	 *         which forced the framework to shutdown. </li>
-	 * 
-	 *         <li> {@link FrameworkEvent#WAIT_TIMEDOUT WAIT_TIMEDOUT} - This
+	 *         which forced the framework to shutdown.</li>
+	 *         <li>{@link FrameworkEvent#WAIT_TIMEDOUT WAIT_TIMEDOUT} - This
 	 *         method has timed out and returned before this Framework has
 	 *         stopped.</li>
 	 *         </ul>
 	 * @throws InterruptedException If another thread interrupted the current
-	 *         thread before or while the current thread was waiting for this
-	 *         Framework to completely stop. The <i>interrupted status</i> of
-	 *         the current thread is cleared when this exception is thrown.
+	 *             thread before or while the current thread was waiting for
+	 *             this Framework to completely stop. The <i>interrupted
+	 *             status</i> of the current thread is cleared when this
+	 *             exception is thrown.
 	 * @throws IllegalArgumentException If the value of timeout is negative.
 	 */
 	FrameworkEvent waitForStop(long timeout) throws InterruptedException;

--- a/osgi.specs/docbook/core/004/framework.lifecycle.xml
+++ b/osgi.specs/docbook/core/004/framework.lifecycle.xml
@@ -1532,6 +1532,14 @@
         </listitem>
 
         <listitem>
+          <para><xref
+          linkend="org.osgi.framework.FrameworkEvent.STOPPED_SYSTEM_REFRESHED"
+          xrefstyle="hyperlink"/> - This <code>Framework</code> object has
+          been stopped because of a refresh operation on the system bundle
+          and the framework requires a new class loader to be used to restart.</para>
+        </listitem>
+
+        <listitem>
           <para><xref linkend="org.osgi.framework.FrameworkEvent.ERROR"
           xrefstyle="hyperlink"/> - The Framework encountered an error while
           shutting down or an error has occurred that forced the framework to


### PR DESCRIPTION
When the org.osgi.framework.FrameworkEvent.STOPPED_SYSTEM_REFRESHED
event was added in OSGi R7 the waitForStop method was not updated
to include the new event as a return type.