### PR TITLE
function: Update with default and static methods for Java 8

### DIFF
--- a/org.osgi.util.function/src/org/osgi/util/function/Consumer.java
+++ b/org.osgi.util.function/src/org/osgi/util/function/Consumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) OSGi Alliance (2017). All Rights Reserved.
+ * Copyright (c) OSGi Alliance (2017, 2020). All Rights Reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.osgi.util.function;
+
+import static java.util.Objects.requireNonNull;
 
 import org.osgi.annotation.versioning.ConsumerType;
 
@@ -39,4 +41,84 @@ public interface Consumer<T> {
 	 * @throws Exception An exception thrown by the method.
 	 */
 	void accept(T t) throws Exception;
+
+	/**
+	 * Compose the specified {@code Consumer} to be called after this
+	 * {@code Consumer}.
+	 * 
+	 * @param after The {@code Consumer} to be called after this
+	 *            {@code Consumer} is called. Must not be {@code null}.
+	 * @return A {@code Consumer} composed of this {@code Consumer} and the
+	 *         specified {@code Consumer}.
+	 */
+	default Consumer<T> andThen(Consumer< ? super T> after) {
+		requireNonNull(after);
+		return t -> {
+			accept(t);
+			after.accept(t);
+		};
+	}
+
+	/**
+	 * Returns a {@code java.util.function.Consumer} which wraps the specified
+	 * {@code Consumer} and throws any thrown exceptions.
+	 * <p>
+	 * The returned {@code java.util.function.Consumer} will throw any exception
+	 * thrown by the wrapped {@code Consumer}.
+	 * 
+	 * @param <T> The type of the function input.
+	 * @param wrapped The {@code Consumer} to wrap. Must not be {@code null}.
+	 * @return A {@code java.util.function.Consumer} which wraps the specified
+	 *         {@code Consumer}.
+	 */
+	static <T> java.util.function.Consumer<T> asJavaConsumer(
+			Consumer<T> wrapped) {
+		requireNonNull(wrapped);
+		return t -> {
+			try {
+				wrapped.accept(t);
+			} catch (Exception e) {
+				throw Exceptions.throwUnchecked(e);
+			}
+		};
+	}
+
+	/**
+	 * Returns a {@code java.util.function.Consumer} which wraps the specified
+	 * {@code Consumer} and discards any thrown {@code Exception}s.
+	 * <p>
+	 * The returned {@code java.util.function.Consumer} will discard any
+	 * {@code Exception} thrown by the wrapped {@code Consumer}.
+	 * 
+	 * @param <T> The type of the function input.
+	 * @param wrapped The {@code Consumer} to wrap. Must not be {@code null}.
+	 * @return A {@code java.util.function.Consumer} which wraps the specified
+	 *         {@code Consumer}.
+	 */
+	static <T> java.util.function.Consumer<T> asJavaConsumerIgnoreException(
+			Consumer<T> wrapped) {
+		requireNonNull(wrapped);
+		return t -> {
+			try {
+				wrapped.accept(t);
+			} catch (Exception e) {
+				// discard
+			}
+		};
+	}
+
+	/**
+	 * Returns a {@code Consumer} which wraps a
+	 * {@code java.util.function.Consumer}.
+	 * 
+	 * @param <T> The type of the function input.
+	 * @param wrapped The {@code java.util.function.Consumer} to wrap. Must not
+	 *            be {@code null}.
+	 * @return A {@code Consumer} which wraps the specified
+	 *         {@code java.util.function.Consumer}.
+	 */
+	static <T> Consumer<T> asConsumer(java.util.function.Consumer<T> wrapped) {
+		requireNonNull(wrapped);
+		return wrapped::accept;
+	}
 }

--- a/org.osgi.util.function/src/org/osgi/util/function/Exceptions.java
+++ b/org.osgi.util.function/src/org/osgi/util/function/Exceptions.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.osgi.util.function;
+
+class Exceptions {
+	private Exceptions() {
+	}
+
+	static RuntimeException throwUnchecked(Throwable t) {
+		throwsUnchecked(t);
+		throw new AssertionError("unreachable");
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <UNCHECKED extends Throwable> void throwsUnchecked(
+			Throwable throwable) throws UNCHECKED {
+		throw (UNCHECKED) throwable;
+	}
+}

--- a/org.osgi.util.function/src/org/osgi/util/function/Function.java
+++ b/org.osgi.util.function/src/org/osgi/util/function/Function.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) OSGi Alliance (2014, 2016). All Rights Reserved.
+ * Copyright (c) OSGi Alliance (2014, 2020). All Rights Reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,18 @@
 
 package org.osgi.util.function;
 
+import static java.util.Objects.requireNonNull;
+
 import org.osgi.annotation.versioning.ConsumerType;
 
 /**
  * A function that accepts a single argument and produces a result.
- *
  * <p>
  * This is a functional interface and can be used as the assignment target for a
  * lambda expression or method reference.
  * 
  * @param <T> The type of the function input.
  * @param <R> The type of the function output.
- * 
  * @ThreadSafe
  * @author $Id$
  */
@@ -42,4 +42,136 @@ public interface Function<T, R> {
 	 * @throws Exception An exception thrown by the method.
 	 */
 	R apply(T t) throws Exception;
+
+	/**
+	 * Compose the specified {@code Function} to be called on the value returned
+	 * by this {@code Function}.
+	 * 
+	 * @param <S> The type of the value supplied by the specified
+	 *            {@code Function}.
+	 * @param after The {@code Function} to be called on the value returned by
+	 *            this {@code Function}. Must not be {@code null}.
+	 * @return A {@code Function} composed of this {@code Function} and the
+	 *         specified {@code Function}.
+	 */
+	default <S> Function<T,S> andThen(Function< ? super R, ? extends S> after) {
+		requireNonNull(after);
+		return t -> after.apply(apply(t));
+	}
+
+	/**
+	 * Compose the specified {@code Function} to be called to supply a value to
+	 * be consumed by this {@code Function}.
+	 * 
+	 * @param <S> The type of the value consumed the specified {@code Function}.
+	 * @param before The {@code Function} to be called to supply a value to be
+	 *            consumed by this {@code Function}. Must not be {@code null}.
+	 * @return A {@code Function} composed of this {@code Function} and the
+	 *         specified {@code Function}.
+	 */
+	default <S> Function<S,R> compose(
+			Function< ? super S, ? extends T> before) {
+		requireNonNull(before);
+		return s -> apply(before.apply(s));
+	}
+
+	/**
+	 * Returns a {@code java.util.function.Function} which wraps the specified
+	 * {@code Function} and throws any thrown exceptions.
+	 * <p>
+	 * The returned {@code java.util.function.Function} will throw any exception
+	 * thrown by the wrapped {@code Function}.
+	 * 
+	 * @param <T> The type of the function input.
+	 * @param <R> The type of the function output.
+	 * @param wrapped The {@code Function} to wrap. Must not be {@code null}.
+	 * @return A {@code java.util.function.Function} which wraps the specified
+	 *         {@code Function}.
+	 */
+	static <T, R> java.util.function.Function<T,R> asJavaFunction(
+			Function<T,R> wrapped) {
+		requireNonNull(wrapped);
+		return t -> {
+			try {
+				return wrapped.apply(t);
+			} catch (Exception e) {
+				throw Exceptions.throwUnchecked(e);
+			}
+		};
+	}
+
+	/**
+	 * Returns a {@code java.util.function.Function} which wraps the specified
+	 * {@code Function} and the specified value.
+	 * <p>
+	 * If the the specified {@code Function} throws an {@code Exception}, the
+	 * the specified value is returned.
+	 * 
+	 * @param <T> The type of the function input.
+	 * @param <R> The type of the function output.
+	 * @param wrapped The {@code Function} to wrap. Must not be {@code null}.
+	 * @param orElse The value to return if the specified {@code Function}
+	 *            throws an {@code Exception}.
+	 * @return A {@code java.util.function.Function} which wraps the specified
+	 *         {@code Function} and the specified value.
+	 */
+	static <T, R> java.util.function.Function<T,R> asJavaFunctionOrElse(
+			Function<T,R> wrapped, R orElse) {
+		requireNonNull(wrapped);
+		return t -> {
+			try {
+				return wrapped.apply(t);
+			} catch (Exception e) {
+				return orElse;
+			}
+		};
+	}
+
+	/**
+	 * Returns a {@code java.util.function.Function} which wraps the specified
+	 * {@code Function} and the specified {@code java.util.function.Supplier}.
+	 * <p>
+	 * If the the specified {@code Function} throws an {@code Exception}, the
+	 * value returned by the specified {@code java.util.function.Supplier} is
+	 * returned.
+	 * 
+	 * @param <T> The type of the function input.
+	 * @param <R> The type of the function output.
+	 * @param wrapped The {@code Function} to wrap. Must not be {@code null}.
+	 * @param orElseGet The {@code java.util.function.Supplier} to call for a
+	 *            return value if the specified {@code Function} throws an
+	 *            {@code Exception}.
+	 * @return A {@code java.util.function.Function} which wraps the specified
+	 *         {@code Function} and the specified
+	 *         {@code java.util.function.Supplier}.
+	 */
+	static <T, R> java.util.function.Function<T,R> asJavaFunctionOrElseGet(
+			Function<T,R> wrapped,
+			java.util.function.Supplier< ? extends R> orElseGet) {
+		requireNonNull(wrapped);
+		return t -> {
+			try {
+				return wrapped.apply(t);
+			} catch (Exception e) {
+				return orElseGet.get();
+			}
+		};
+	}
+
+	/**
+	 * Returns a {@code Function} which wraps the specified
+	 * {@code java.util.function.Function}.
+	 * 
+	 * @param <T> The type of the function input.
+	 * @param <R> The type of the function output.
+	 * @param wrapped The {@code java.util.function.Function} to wrap. Must not
+	 *            be {@code null}.
+	 * @return A {@code Function} which wraps the specified
+	 *         {@code java.util.function.Function}.
+	 */
+	static <T, R> Function<T,R> asFunction(
+			java.util.function.Function<T,R> wrapped) {
+		requireNonNull(wrapped);
+		return wrapped::apply;
+	}
 }

--- a/org.osgi.util.function/src/org/osgi/util/function/Predicate.java
+++ b/org.osgi.util.function/src/org/osgi/util/function/Predicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) OSGi Alliance (2014, 2016). All Rights Reserved.
+ * Copyright (c) OSGi Alliance (2014, 2020). All Rights Reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,17 @@
 
 package org.osgi.util.function;
 
+import static java.util.Objects.requireNonNull;
+
 import org.osgi.annotation.versioning.ConsumerType;
 
 /**
  * A predicate that accepts a single argument and produces a boolean result.
- *
  * <p>
  * This is a functional interface and can be used as the assignment target for a
  * lambda expression or method reference.
  * 
  * @param <T> The type of the predicate input.
- * 
  * @ThreadSafe
  * @author $Id$
  */
@@ -42,4 +42,146 @@ public interface Predicate<T> {
 	 * @throws Exception An exception thrown by the method.
 	 */
 	boolean test(T t) throws Exception;
+
+	/**
+	 * Return a {@code Predicate} which is the negation of this
+	 * {@code Predicate}.
+	 * 
+	 * @return A {@code Predicate} which is the negation of this
+	 *         {@code Predicate}.
+	 */
+	default Predicate<T> negate() {
+		return t -> !test(t);
+	}
+
+	/**
+	 * Compose this {@code Predicate} logical-AND the specified
+	 * {@code Predicate}.
+	 * <p>
+	 * Short-circuiting is used, so the specified {@code Predicate} is not
+	 * called if this {@code Predicate} returns {@code false}.
+	 * 
+	 * @param and The {@code Predicate} to be called after this
+	 *            {@code Predicate} is called. Must not be {@code null}.
+	 * @return A {@code Predicate} composed of this {@code Predicate} and the
+	 *         specified {@code Predicate} using logical-AND.
+	 */
+	default Predicate<T> and(Predicate< ? super T> and) {
+		requireNonNull(and);
+		return t -> test(t) && and.test(t);
+	}
+
+	/**
+	 * Compose this {@code Predicate} logical-OR the specified
+	 * {@code Predicate}.
+	 * <p>
+	 * Short-circuiting is used, so the specified {@code Predicate} is not
+	 * called if this {@code Predicate} returns {@code true}.
+	 * 
+	 * @param or The {@code Predicate} to be called after this {@code Predicate}
+	 *            is called. Must not be {@code null}.
+	 * @return A {@code Predicate} composed of this {@code Predicate} and the
+	 *         specified {@code Predicate} using logical-OR.
+	 */
+	default Predicate<T> or(Predicate< ? super T> or) {
+		requireNonNull(or);
+		return t -> test(t) || or.test(t);
+	}
+
+	/**
+	 * Returns a {@code java.util.function.Predicate} which wraps the specified
+	 * {@code Predicate} and throws any thrown exceptions.
+	 * <p>
+	 * The returned {@code java.util.function.Predicate} will throw any
+	 * exception thrown by the wrapped {@code Predicate}.
+	 * 
+	 * @param <T> The type of the predicate input.
+	 * @param wrapped The {@code Predicate} to wrap. Must not be {@code null}.
+	 * @return A {@code java.util.function.Predicate} which wraps the specified
+	 *         {@code Predicate}.
+	 */
+	static <T> java.util.function.Predicate<T> asJavaPredicate(
+			Predicate<T> wrapped) {
+		requireNonNull(wrapped);
+		return t -> {
+			try {
+				return wrapped.test(t);
+			} catch (Exception e) {
+				throw Exceptions.throwUnchecked(e);
+			}
+		};
+	}
+
+	/**
+	 * Returns a {@code java.util.function.Predicate} which wraps the specified
+	 * {@code Predicate} and the specified value.
+	 * <p>
+	 * If the the specified {@code Predicate} throws an {@code Exception}, the
+	 * the specified value is returned.
+	 * 
+	 * @param <T> The type of the predicate input.
+	 * @param wrapped The {@code Predicate} to wrap. Must not be {@code null}.
+	 * @param orElse The value to return if the specified {@code Predicate}
+	 *            throws an {@code Exception}.
+	 * @return A {@code java.util.function.Predicate} which wraps the specified
+	 *         {@code Predicate} and the specified value.
+	 */
+	static <T> java.util.function.Predicate<T> asJavaPredicateOrElse(
+			Predicate<T> wrapped, boolean orElse) {
+		requireNonNull(wrapped);
+		return t -> {
+			try {
+				return wrapped.test(t);
+			} catch (Exception e) {
+				return orElse;
+			}
+		};
+	}
+
+	/**
+	 * Returns a {@code java.util.function.Predicate} which wraps the specified
+	 * {@code Predicate} and the specified
+	 * {@code java.util.function.BooleanSupplier}.
+	 * <p>
+	 * If the the specified {@code Predicate} throws an {@code Exception}, the
+	 * value returned by the specified
+	 * {@code java.util.function.BooleanSupplier} is returned.
+	 * 
+	 * @param <T> The type of the predicate input.
+	 * @param wrapped The {@code Predicate} to wrap. Must not be {@code null}.
+	 * @param orElseGet The {@code java.util.function.BooleanSupplier} to call
+	 *            for a return value if the specified {@code Predicate} throws
+	 *            an {@code Exception}.
+	 * @return A {@code java.util.function.Predicate} which wraps the specified
+	 *         {@code Predicate} and the specified
+	 *         {@code java.util.function.BooleanSupplier}.
+	 */
+	static <T> java.util.function.Predicate<T> asJavaPredicateOrElseGet(
+			Predicate<T> wrapped,
+			java.util.function.BooleanSupplier orElseGet) {
+		requireNonNull(wrapped);
+		return t -> {
+			try {
+				return wrapped.test(t);
+			} catch (Exception e) {
+				return orElseGet.getAsBoolean();
+			}
+		};
+	}
+
+	/**
+	 * Returns a {@code Predicate} which wraps the specified
+	 * {@code java.util.function.Predicate}.
+	 * 
+	 * @param <T> The type of the predicate input.
+	 * @param wrapped The {@code java.util.function.Predicate} to wrap. Must not
+	 *            be {@code null}.
+	 * @return A {@code Predicate} which wraps the specified
+	 *         {@code java.util.function.Predicate}.
+	 */
+	static <T> Predicate<T> asPredicate(
+			java.util.function.Predicate<T> wrapped) {
+		requireNonNull(wrapped);
+		return wrapped::test;
+	}
 }

--- a/org.osgi.util.function/src/org/osgi/util/function/Supplier.java
+++ b/org.osgi.util.function/src/org/osgi/util/function/Supplier.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) OSGi Alliance (2020). All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.osgi.util.function;
+
+import static java.util.Objects.requireNonNull;
+
+import org.osgi.annotation.versioning.ConsumerType;
+
+/**
+ * A function that produces a result.
+ * <p>
+ * This is a functional interface and can be used as the assignment target for a
+ * lambda expression or method reference.
+ * 
+ * @param <T> The type of the function output.
+ * @ThreadSafe
+ * @author $Id$
+ */
+@ConsumerType
+@FunctionalInterface
+public interface Supplier<T> {
+	/**
+	 * Returns a value.
+	 * 
+	 * @return The output of this function.
+	 * @throws Exception An exception thrown by the method.
+	 */
+	T get() throws Exception;
+
+	/**
+	 * Returns a {@code java.util.function.Supplier} which wraps the specified
+	 * {@code Supplier} and throws any thrown exceptions.
+	 * <p>
+	 * The returned {@code java.util.function.Supplier} will throw any exception
+	 * thrown by the wrapped {@code Supplier}.
+	 * 
+	 * @param <T> The type of the function output.
+	 * @param wrapped The {@code Supplier} to wrap. Must not be {@code null}.
+	 * @return A {@code java.util.function.Supplier} which wraps the specified
+	 *         {@code Supplier}.
+	 */
+	static <T> java.util.function.Supplier<T> asJavaSupplier(
+			Supplier<T> wrapped) {
+		requireNonNull(wrapped);
+		return () -> {
+			try {
+				return wrapped.get();
+			} catch (Exception e) {
+				throw Exceptions.throwUnchecked(e);
+			}
+		};
+	}
+
+	/**
+	 * Returns a {@code java.util.function.Supplier} which wraps the specified
+	 * {@code Supplier} and the specified value.
+	 * <p>
+	 * If the the specified {@code Supplier} throws an {@code Exception}, the
+	 * the specified value is returned.
+	 * 
+	 * @param <T> The type of the function output.
+	 * @param wrapped The {@code Supplier} to wrap. Must not be {@code null}.
+	 * @param orElse The value to return if the specified {@code Supplier}
+	 *            throws an {@code Exception}.
+	 * @return A {@code java.util.function.Supplier} which wraps the specified
+	 *         {@code Supplier} and the specified value.
+	 */
+	static <T> java.util.function.Supplier<T> asJavaSupplierOrElse(
+			Supplier<T> wrapped, T orElse) {
+		requireNonNull(wrapped);
+		return () -> {
+			try {
+				return wrapped.get();
+			} catch (Exception e) {
+				return orElse;
+			}
+		};
+	}
+
+	/**
+	 * Returns a {@code java.util.function.Supplier} which wraps the specified
+	 * {@code Supplier} and the specified {@code java.util.function.Supplier}.
+	 * <p>
+	 * If the the specified {@code Supplier} throws an {@code Exception}, the
+	 * value returned by the specified {@code java.util.function.Supplier} is
+	 * returned.
+	 * 
+	 * @param <T> The type of the function output.
+	 * @param wrapped The {@code Supplier} to wrap. Must not be {@code null}.
+	 * @param orElseGet The {@code java.util.function.Supplier} to call for a
+	 *            return value if the specified {@code Supplier} throws an
+	 *            {@code Exception}.
+	 * @return A {@code java.util.function.Supplier} which wraps the specified
+	 *         {@code Supplier} and the specified
+	 *         {@code java.util.function.Supplier}.
+	 */
+	static <T> java.util.function.Supplier<T> asJavaSupplierOrElseGet(
+			Supplier<T> wrapped,
+			java.util.function.Supplier< ? extends T> orElseGet) {
+		requireNonNull(wrapped);
+		return () -> {
+			try {
+				return wrapped.get();
+			} catch (Exception e) {
+				return orElseGet.get();
+			}
+		};
+	}
+
+	/**
+	 * Returns a {@code Supplier} which wraps the specified
+	 * {@code java.util.function.Supplier}.
+	 * 
+	 * @param <T> The type of the function output.
+	 * @param wrapped The {@code java.util.function.Supplier} to wrap. Must not
+	 *            be {@code null}.
+	 * @return A {@code Supplier} which wraps the specified
+	 *         {@code java.util.Supplier.Function}.
+	 */
+	static <T> Supplier<T> asSupplier(java.util.function.Supplier<T> wrapped) {
+		requireNonNull(wrapped);
+		return wrapped::get;
+	}
+}

--- a/org.osgi.util.function/src/org/osgi/util/function/package-info.java
+++ b/org.osgi.util.function/src/org/osgi/util/function/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) OSGi Alliance (2014, 2016). All Rights Reserved.
+ * Copyright (c) OSGi Alliance (2014, 2020). All Rights Reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,23 @@
  */
 
 /**
- * Function Package Version 1.1.
+ * Function Package Version 1.2.
  * <p>
  * Bundles wishing to use this package must list the package in the
  * Import-Package header of the bundle's manifest.
  * <p>
  * Example import for consumers using the API in this package:
  * <p>
- * {@code  Import-Package: org.osgi.util.function; version="[1.1,2.0)"}
+ * {@code  Import-Package: org.osgi.util.function; version="[1.2,2.0)"}
  * <p>
  * Example import for providers implementing the API in this package:
  * <p>
- * {@code  Import-Package: org.osgi.util.function; version="[1.1,1.2)"}
+ * {@code  Import-Package: org.osgi.util.function; version="[1.2,1.3)"}
  * 
  * @author $Id$
  */
 
-@Version("1.1")
+@Version("1.2")
 package org.osgi.util.function;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Now that we are on Java 8, we should provide some additional methods
in the function package.

We include counterparts to the convenience methods in the juf types as
well as static methods to "convert" to and from the juf types.