### PR TITLE
ct: Simplify testcases.junit5 macro

### DIFF
--- a/cnf/osgi.ct.junit-platform.bnd
+++ b/cnf/osgi.ct.junit-platform.bnd
@@ -11,11 +11,6 @@ repo.osgi.ct: ${repo;osgi.ct.junit-platform;latest}
 
 testcases.junit3 = ${classes;EXTENDS;junit.framework.TestCase;CONCRETE}
 testcases.junit4 = ${classes;HIERARCHY_ANNOTATED;org.junit.Test;CONCRETE}
-testcases.junit5 = \
- ${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.jupiter.api.Test;CONCRETE},\
- ${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.jupiter.api.RepeatedTest;CONCRETE},\
- ${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.jupiter.params.ParameterizedTest;CONCRETE},\
- ${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.jupiter.api.TestFactory;CONCRETE},\
- ${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.jupiter.api.TestTemplate;CONCRETE}
+testcases.junit5 = ${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE}
 
 Test-Cases: ${sort;${uniq;${testcases.junit3};${testcases.junit4};${testcases.junit5}}}


### PR DESCRIPTION
We now use the marker annotation
org.junit.platform.commons.annotation.Testable.