### PR TITLE
build: Use include files to project package type

### DIFF
--- a/cnf/annotation.bnd
+++ b/cnf/annotation.bnd
@@ -1,0 +1,6 @@
+# bnd instructions for Annotation projects
+
+# Uncomment the following line to build the non-snapshot version.
+#-snapshot:
+
+packaging: annotation

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -73,8 +73,7 @@ osgi.annotation.version=7.0.0
 -groupid: org.osgi
 Bundle-Copyright: ${copyright}
 Bundle-Vendor:    OSGi Alliance https://www.osgi.org/
-# Uncomment the following line to build the non-snapshot version.
-#-snapshot:
+# To build the non-snapshot version, see the packaging bnd files for -snapshot.
 Bundle-Version:   ${build.version}-SNAPSHOT
 Bundle-DocURL:    https://www.osgi.org/
 Git-Descriptor:   ${system-allow-fail;git describe --dirty --always --abbrev=9}

--- a/cnf/cmpn.bnd
+++ b/cnf/cmpn.bnd
@@ -1,0 +1,6 @@
+# bnd instructions for Compendium projects
+
+# Uncomment the following line to build the non-snapshot version.
+#-snapshot:
+
+packaging: cmpn

--- a/cnf/core.bnd
+++ b/cnf/core.bnd
@@ -1,0 +1,6 @@
+# bnd instructions for Core projects
+
+# Uncomment the following line to build the non-snapshot version.
+#-snapshot:
+
+packaging: core

--- a/cnf/promise.bnd
+++ b/cnf/promise.bnd
@@ -1,0 +1,6 @@
+# bnd instructions for Promise projects
+
+# Uncomment the following line to build the non-snapshot version.
+#-snapshot:
+
+packaging: cmpn,promise

--- a/org.osgi.annotation.bundle/bnd.bnd
+++ b/org.osgi.annotation.bundle/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/annotation.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.annotation.versioning/bnd.bnd
+++ b/org.osgi.annotation.versioning/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/annotation.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.dto/bnd.bnd
+++ b/org.osgi.dto/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/core.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.framework/bnd.bnd
+++ b/org.osgi.framework/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/core.bnd
 
 Export-Package: ${p}.*; -split-package:=first; -noimport:=true
 

--- a/org.osgi.impl.bundle.annotations/bnd.bnd
+++ b/org.osgi.impl.bundle.annotations/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/core.bnd
 
 Bundle-Description			= Annotations Test Bundle
 

--- a/org.osgi.impl.bundle.component.annotations/bnd.bnd
+++ b/org.osgi.impl.bundle.component.annotations/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Description			= DS Annotations Test Bundle
 

--- a/org.osgi.impl.bundle.jaxp/bnd.bnd
+++ b/org.osgi.impl.bundle.jaxp/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator				= org.osgi.impl.bundle.jaxp.JaxpActivator
 Bundle-Description				=  OSGi XML JAXP Implementation. Registers an 

--- a/org.osgi.impl.bundle.metatype.annotations/bnd.bnd
+++ b/org.osgi.impl.bundle.metatype.annotations/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Description			= Metatype Annotations Test Bundle
 

--- a/org.osgi.impl.bundle.rsh/bnd.bnd
+++ b/org.osgi.impl.bundle.rsh/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator				= ${p}.RshHandler
 Bundle-Description				= OSGi rsh URL handler reference implementation by IBM Corporation.

--- a/org.osgi.impl.bundle.transaction/bnd.bnd
+++ b/org.osgi.impl.bundle.transaction/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Description				= OSGi Transaction reference implementation by ProSyst.
 

--- a/org.osgi.impl.service.async/bnd.bnd
+++ b/org.osgi.impl.service.async/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator				= ${p}.Activator
 

--- a/org.osgi.impl.service.dal.step/bnd.bnd
+++ b/org.osgi.impl.service.dal.step/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Vendor		= ProSyst
 Bundle-Activator	= ${p}.Activator

--- a/org.osgi.impl.service.dal/bnd.bnd
+++ b/org.osgi.impl.service.dal/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Vendor		= ProSyst
 Bundle-Activator	= ${p}.Activator

--- a/org.osgi.impl.service.device.manager/bnd.bnd
+++ b/org.osgi.impl.service.device.manager/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator				= ${p}.Activator
 Import-Service					= org.osgi.service.log.LogService

--- a/org.osgi.impl.service.dmt/bnd.bnd
+++ b/org.osgi.impl.service.dmt/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Vendor					= Nokia
 Bundle-Activator				= ${p}.Activator

--- a/org.osgi.impl.service.enocean/bnd.bnd
+++ b/org.osgi.impl.service.enocean/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Vendor		= Orange
 Bundle-Activator	= org.osgi.impl.service.enocean.EnOceanBundleActivator

--- a/org.osgi.impl.service.jdbc/bnd.bnd
+++ b/org.osgi.impl.service.jdbc/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator: 		${p}.Activator
 Export-Package: 		org.osgi.service.jdbc; -split-package:=first; provide:=true

--- a/org.osgi.impl.service.jndi/bnd.bnd
+++ b/org.osgi.impl.service.jndi/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact3
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator			= org.osgi.impl.service.jndi.Activator
 Bundle-Description			= OSGi JNDI Reference Implementation by Oracle Corporation.

--- a/org.osgi.impl.service.networkadapter/bnd.bnd
+++ b/org.osgi.impl.service.networkadapter/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator			= ${p}.Activator
 Bundle-Description			= Network Interface Information Service for a Reference Implementation.

--- a/org.osgi.impl.service.onem2m/bnd.bnd
+++ b/org.osgi.impl.service.onem2m/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator: ${p}.Activator
 

--- a/org.osgi.impl.service.prefs/bnd.bnd
+++ b/org.osgi.impl.service.prefs/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator			= ${p}.Activator
 Bundle-Description			= OSGi Preferences Service Reference Implementation by Sun Microsystems.

--- a/org.osgi.impl.service.residentialmanagement/bnd.bnd
+++ b/org.osgi.impl.service.residentialmanagement/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator	= $(p).plugins.ResidentialPluginActivator
 

--- a/org.osgi.impl.service.resourcemonitoring.fakemonitors/bnd.bnd
+++ b/org.osgi.impl.service.resourcemonitoring.fakemonitors/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Vendor				= Orange
 Bundle-Activator: org.osgi.impl.service.resourcemonitoring.fakemonitors.Activator

--- a/org.osgi.impl.service.resourcemonitoring.util/bnd.bnd
+++ b/org.osgi.impl.service.resourcemonitoring.util/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Vendor				= Orange
 Bundle-Description: Resource Monitoring Utils provides classes common for Resource Monitor Factories bundles. It includes the EventNotifier class which can be used by Resource Monitor to notify all their related ResourceListeners.

--- a/org.osgi.impl.service.resourcemonitoring/bnd.bnd
+++ b/org.osgi.impl.service.resourcemonitoring/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Vendor				= Orange
 Bundle-Activator			= org.osgi.impl.service.resourcemonitoring.Activator

--- a/org.osgi.impl.service.rest.client.js/bnd.bnd
+++ b/org.osgi.impl.service.rest.client.js/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 -resourceonly       : true
 -includeresource: script/OSGiRestClient.js=src/OSGiRestClient.js

--- a/org.osgi.impl.service.rest.client/bnd.bnd
+++ b/org.osgi.impl.service.rest.client/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 -privatepackage 				= ${p}.*
 Export-Package					= org.osgi.service.rest.client; -split-package:=first

--- a/org.osgi.impl.service.rest/bnd.bnd
+++ b/org.osgi.impl.service.rest/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator				= ${p}.Activator
 

--- a/org.osgi.impl.service.serial/bnd.bnd
+++ b/org.osgi.impl.service.serial/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator			= ${p}.Activator
 Bundle-Description			= Serial Device Service for a Reference Implementation.

--- a/org.osgi.impl.service.tr069todmt/bnd.bnd
+++ b/org.osgi.impl.service.tr069todmt/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator = ${p}.TR069ConnectorFactoryImpl
 Export-Package = org.osgi.service.tr069todmt; -split-package:=first; provide:=true

--- a/org.osgi.impl.service.upnp.cd/bnd.bnd
+++ b/org.osgi.impl.service.upnp.cd/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Vendor				= Samsung
 Bundle-Activator			= ${p}.UPnPController

--- a/org.osgi.impl.service.upnp.cp/bnd.bnd
+++ b/org.osgi.impl.service.upnp.cp/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Vendor				= Samsung
 Bundle-Activator			= org.osgi.impl.service.upnp.cp.UPnPBundleActivator

--- a/org.osgi.impl.service.usbinfo/bnd.bnd
+++ b/org.osgi.impl.service.usbinfo/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator			= ${p}.Activator
 Bundle-Description			= USB Information Base Driver for a Reference Implementation.

--- a/org.osgi.impl.service.useradmin/bnd.bnd
+++ b/org.osgi.impl.service.useradmin/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator: org.osgi.impl.service.useradmin.Activator
 Bundle-Description: OSGi UserAdmin Service Reference Implementation by Gatespace AB.

--- a/org.osgi.impl.service.zigbee/bnd.bnd
+++ b/org.osgi.impl.service.zigbee/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Vendor				= Orange and TIM
 Bundle-Activator			= ${p}.ZigBeeBundleActivator

--- a/org.osgi.jmx/bnd.bnd
+++ b/org.osgi.jmx/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact3
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.namespace.contract/bnd.bnd
+++ b/org.osgi.namespace.contract/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.namespace.extender/bnd.bnd
+++ b/org.osgi.namespace.extender/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.namespace.implementation/bnd.bnd
+++ b/org.osgi.namespace.implementation/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.namespace.service/bnd.bnd
+++ b/org.osgi.namespace.service/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.namespace.unresolvable/bnd.bnd
+++ b/org.osgi.namespace.unresolvable/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.resource/bnd.bnd
+++ b/org.osgi.resource/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/core.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.async/bnd.bnd
+++ b/org.osgi.service.async/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.cdi/bnd.bnd
+++ b/org.osgi.service.cdi/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.clusterinfo/bnd.bnd
+++ b/org.osgi.service.clusterinfo/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.cm/bnd.bnd
+++ b/org.osgi.service.cm/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.component.annotations/bnd.bnd
+++ b/org.osgi.service.component.annotations/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.component/bnd.bnd
+++ b/org.osgi.service.component/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: !${p}.annotations, ${p}.*; -split-package:=first
 

--- a/org.osgi.service.condition/bnd.bnd
+++ b/org.osgi.service.condition/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/core.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.conditionfactory/bnd.bnd
+++ b/org.osgi.service.conditionfactory/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.condpermadmin/bnd.bnd
+++ b/org.osgi.service.condpermadmin/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/core.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.configurator/bnd.bnd
+++ b/org.osgi.service.configurator/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.coordinator/bnd.bnd
+++ b/org.osgi.service.coordinator/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.dal.functions/bnd.bnd
+++ b/org.osgi.service.dal.functions/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.dal/bnd.bnd
+++ b/org.osgi.service.dal/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.device/bnd.bnd
+++ b/org.osgi.service.device/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.dmt/bnd.bnd
+++ b/org.osgi.service.dmt/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.enocean/bnd.bnd
+++ b/org.osgi.service.enocean/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.event/bnd.bnd
+++ b/org.osgi.service.event/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.http.whiteboard/bnd.bnd
+++ b/org.osgi.service.http.whiteboard/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package:  \
 	org.osgi.service.http.*;-split-package:=first

--- a/org.osgi.service.http/bnd.bnd
+++ b/org.osgi.service.http/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.jaxrs/bnd.bnd
+++ b/org.osgi.service.jaxrs/bnd.bnd
@@ -1,7 +1,7 @@
 # Since the ${p} is not a package in this project
 spec.package = ${p}.whiteboard
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.jdbc/bnd.bnd
+++ b/org.osgi.service.jdbc/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.jndi/bnd.bnd
+++ b/org.osgi.service.jndi/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact3
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.jpa/bnd.bnd
+++ b/org.osgi.service.jpa/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.log.stream/bnd.bnd
+++ b/org.osgi.service.log.stream/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.log/bnd.bnd
+++ b/org.osgi.service.log/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/core.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.metatype.annotations/bnd.bnd
+++ b/org.osgi.service.metatype.annotations/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.metatype/bnd.bnd
+++ b/org.osgi.service.metatype/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: !${p}.annotations, ${p}.*; -split-package:=first
 

--- a/org.osgi.service.networkadapter/bnd.bnd
+++ b/org.osgi.service.networkadapter/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.onem2m/bnd.bnd
+++ b/org.osgi.service.onem2m/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.packageadmin/bnd.bnd
+++ b/org.osgi.service.packageadmin/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/core.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.permissionadmin/bnd.bnd
+++ b/org.osgi.service.permissionadmin/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/core.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.prefs/bnd.bnd
+++ b/org.osgi.service.prefs/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.provisioning/bnd.bnd
+++ b/org.osgi.service.provisioning/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.remoteserviceadmin/bnd.bnd
+++ b/org.osgi.service.remoteserviceadmin/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.repository/bnd.bnd
+++ b/org.osgi.service.repository/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.resolver/bnd.bnd
+++ b/org.osgi.service.resolver/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/core.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.resourcemonitoring/bnd.bnd
+++ b/org.osgi.service.resourcemonitoring/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.rest/bnd.bnd
+++ b/org.osgi.service.rest/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.serial/bnd.bnd
+++ b/org.osgi.service.serial/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.serviceloader/bnd.bnd
+++ b/org.osgi.service.serviceloader/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.startlevel/bnd.bnd
+++ b/org.osgi.service.startlevel/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/core.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.tr069todmt/bnd.bnd
+++ b/org.osgi.service.tr069todmt/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.transaction.control/bnd.bnd
+++ b/org.osgi.service.transaction.control/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.typedevent/bnd.bnd
+++ b/org.osgi.service.typedevent/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.upnp/bnd.bnd
+++ b/org.osgi.service.upnp/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.url/bnd.bnd
+++ b/org.osgi.service.url/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/core.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.usbinfo/bnd.bnd
+++ b/org.osgi.service.usbinfo/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.useradmin/bnd.bnd
+++ b/org.osgi.service.useradmin/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.wireadmin/bnd.bnd
+++ b/org.osgi.service.wireadmin/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.service.zigbee/bnd.bnd
+++ b/org.osgi.service.zigbee/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.test.cases.async.secure/bnd.bnd
+++ b/org.osgi.test.cases.async.secure/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.async/bnd.bnd
+++ b/org.osgi.test.cases.async/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.bundle.annotations/bnd.bnd
+++ b/org.osgi.test.cases.bundle.annotations/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/core.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.cdi.secure/bnd.bnd
+++ b/org.osgi.test.cases.cdi.secure/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Secure CT for the OSGi/CDI integration
 -conditionalpackage: org.osgi.test.support.*

--- a/org.osgi.test.cases.cdi/bnd.bnd
+++ b/org.osgi.test.cases.cdi/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: CT for the OSGi/CDI integration
 -conditionalpackage: org.osgi.test.support.*

--- a/org.osgi.test.cases.clusterinfo.secure/bnd.bnd
+++ b/org.osgi.test.cases.clusterinfo.secure/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description                  : A test case for the clusterinfo implementation.
 

--- a/org.osgi.test.cases.clusterinfo/bnd.bnd
+++ b/org.osgi.test.cases.clusterinfo/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description                  : A test case for the clusterinfo implementation.
 

--- a/org.osgi.test.cases.cm/bnd.bnd
+++ b/org.osgi.test.cases.cm/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Configuration Management Test R7
 Bundle-Vendor: OSGi Alliance

--- a/org.osgi.test.cases.component.annotations/bnd.bnd
+++ b/org.osgi.test.cases.component.annotations/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.component/bnd.bnd
+++ b/org.osgi.test.cases.component/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Declarative Services Test Case
 -debug: true

--- a/org.osgi.test.cases.condpermadmin/bnd.bnd
+++ b/org.osgi.test.cases.condpermadmin/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit4-runpath.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit4-runpath.bnd, ${build}/core.bnd
 # The test case wipes out permissions for all bundles, so we need
 # to place the tester on the classpath rather than being in a bundle.
 

--- a/org.osgi.test.cases.configurator.secure/bnd.bnd
+++ b/org.osgi.test.cases.configurator.secure/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd, ${build}/cmpn.bnd
 
 Bundle-Description                  : A test case for the event generic mechanism implementation.
 

--- a/org.osgi.test.cases.configurator/bnd.bnd
+++ b/org.osgi.test.cases.configurator/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd, ${build}/cmpn.bnd
 
 Bundle-Description                  : A test case for the event generic mechanism implementation.
 

--- a/org.osgi.test.cases.converter/bnd.bnd
+++ b/org.osgi.test.cases.converter/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description = A test case for Converter.
 

--- a/org.osgi.test.cases.coordinator.secure/bnd.bnd
+++ b/org.osgi.test.cases.coordinator.secure/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.coordinator/bnd.bnd
+++ b/org.osgi.test.cases.coordinator/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -includeresource: dummy.jar
 

--- a/org.osgi.test.cases.dal.functions/bnd.bnd
+++ b/org.osgi.test.cases.dal.functions/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Export-Package: org.osgi.test.support.step;-noimport:=true;-split-package:=first, \
  ${p}.step.*;-noimport:=true

--- a/org.osgi.test.cases.dal.secure/bnd.bnd
+++ b/org.osgi.test.cases.dal.secure/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Export-Package: org.osgi.test.support.step;-noimport:=true;-split-package:=first, \
  ${p}.step.*;-noimport:=true

--- a/org.osgi.test.cases.dal/bnd.bnd
+++ b/org.osgi.test.cases.dal/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Export-Package: org.osgi.test.support.step;-noimport:=true, \
  ${p}.step.*;-noimport:=true

--- a/org.osgi.test.cases.device/bnd.bnd
+++ b/org.osgi.test.cases.device/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Export-Package: 		${p}.tbc;-split-package:=first
 -conditionalpackage					= org.osgi.test.support.*

--- a/org.osgi.test.cases.dmt.tc1/bnd.bnd
+++ b/org.osgi.test.cases.dmt.tc1/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Dmt Test Case 001
 -conditionalpackage					= org.osgi.test.support.*

--- a/org.osgi.test.cases.dmt.tc2/bnd.bnd
+++ b/org.osgi.test.cases.dmt.tc2/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Dmt Test Case 002
 -conditionalpackage					= org.osgi.test.support.*

--- a/org.osgi.test.cases.dmt.tc3/bnd.bnd
+++ b/org.osgi.test.cases.dmt.tc3/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Dmt Test Case 003
 -conditionalpackage					= org.osgi.test.support.*

--- a/org.osgi.test.cases.dmt.tc4/bnd.bnd
+++ b/org.osgi.test.cases.dmt.tc4/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Dmt Test Case 004
 -conditionalpackage					= org.osgi.test.support.*

--- a/org.osgi.test.cases.enocean/bnd.bnd
+++ b/org.osgi.test.cases.enocean/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description	= EnOcean Test Bundle
 

--- a/org.osgi.test.cases.event.secure/bnd.bnd
+++ b/org.osgi.test.cases.event.secure/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description					: A security test case for the event generic mechanism implementation.
 

--- a/org.osgi.test.cases.event/bnd.bnd
+++ b/org.osgi.test.cases.event/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description					: A test case for the event generic mechanism implementation.
 

--- a/org.osgi.test.cases.framework.launch.secure/bnd.bnd
+++ b/org.osgi.test.cases.framework.launch.secure/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit4-runpath.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit4-runpath.bnd, ${build}/core.bnd
 
 Bundle-Description					: Framework test cases.
 

--- a/org.osgi.test.cases.framework.launch/bnd.bnd
+++ b/org.osgi.test.cases.framework.launch/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit4-runpath.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit4-runpath.bnd, ${build}/core.bnd
 
 Bundle-Description					: Framework test cases.
 

--- a/org.osgi.test.cases.framework.secure/bnd.bnd
+++ b/org.osgi.test.cases.framework.secure/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/core.bnd
 
 Bundle-Description					: Secure Framework test cases.
 

--- a/org.osgi.test.cases.framework/bnd.bnd
+++ b/org.osgi.test.cases.framework/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/core.bnd
 
 Bundle-Description					: Framework test cases.
 

--- a/org.osgi.test.cases.http.whiteboard.secure/bnd.bnd
+++ b/org.osgi.test.cases.http.whiteboard.secure/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*, \
  org.apache.http.*,\

--- a/org.osgi.test.cases.http.whiteboard/bnd.bnd
+++ b/org.osgi.test.cases.http.whiteboard/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage = org.osgi.test.support.*,\
  org.osgi.util.converter.*,\

--- a/org.osgi.test.cases.http/bnd.bnd
+++ b/org.osgi.test.cases.http/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Test Bundle for Http Service tests
 

--- a/org.osgi.test.cases.jaxrs/bnd.bnd
+++ b/org.osgi.test.cases.jaxrs/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd, ${build}/cmpn.bnd
 
 
 -conditionalpackage: org.osgi.test.support.*,\

--- a/org.osgi.test.cases.jdbc/bnd.bnd
+++ b/org.osgi.test.cases.jdbc/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.jmx.cm/bnd.bnd
+++ b/org.osgi.test.cases.jmx.cm/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact3
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage                 = org.osgi.test.support.*
 -privatepackage                     =  \

--- a/org.osgi.test.cases.jmx.framework.secure/bnd.bnd
+++ b/org.osgi.test.cases.jmx.framework.secure/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact3
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage                 = org.osgi.test.support.*
 -privatepackage                     =  \

--- a/org.osgi.test.cases.jmx.framework/bnd.bnd
+++ b/org.osgi.test.cases.jmx.framework/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact3
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 -noee = true
 
 -conditionalpackage                 = org.osgi.test.support.*

--- a/org.osgi.test.cases.jmx.provisioning/bnd.bnd
+++ b/org.osgi.test.cases.jmx.provisioning/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact3
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage                 = org.osgi.test.support.*
 -privatepackage                     =  \

--- a/org.osgi.test.cases.jmx.useradmin/bnd.bnd
+++ b/org.osgi.test.cases.jmx.useradmin/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact3
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage                 = org.osgi.test.support.*
 -privatepackage                     =  \

--- a/org.osgi.test.cases.jndi.secure/bnd.bnd
+++ b/org.osgi.test.cases.jndi.secure/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact3
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Export-Package						= \
 	${p}.provider, \

--- a/org.osgi.test.cases.jndi/bnd.bnd
+++ b/org.osgi.test.cases.jndi/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact3
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.jpa/bnd.bnd
+++ b/org.osgi.test.cases.jpa/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.log.launch/bnd.bnd
+++ b/org.osgi.test.cases.log.launch/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit4-runpath.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit4-runpath.bnd, ${build}/core.bnd
 
 Bundle-Description					: Framework test cases.
 

--- a/org.osgi.test.cases.log.stream/bnd.bnd
+++ b/org.osgi.test.cases.log.stream/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage: org.osgi.test.support.*
 -includepackage:   \

--- a/org.osgi.test.cases.log/bnd.bnd
+++ b/org.osgi.test.cases.log/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/core.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.metatype.annotations/bnd.bnd
+++ b/org.osgi.test.cases.metatype.annotations/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.metatype/bnd.bnd
+++ b/org.osgi.test.cases.metatype/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Test Bundle for Metatype Service tests
 

--- a/org.osgi.test.cases.networkadapter/bnd.bnd
+++ b/org.osgi.test.cases.networkadapter/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.onem2m/bnd.bnd
+++ b/org.osgi.test.cases.onem2m/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Tests the service layer bundle
 

--- a/org.osgi.test.cases.permissionadmin/bnd.bnd
+++ b/org.osgi.test.cases.permissionadmin/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/core.bnd
 
 Bundle-Category: osgi,test
 Export-Package: ${p}.service

--- a/org.osgi.test.cases.prefs/bnd.bnd
+++ b/org.osgi.test.cases.prefs/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Test Bundle for Preference Service tests
 

--- a/org.osgi.test.cases.promise/bnd.bnd
+++ b/org.osgi.test.cases.promise/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd, ${build}/cmpn.bnd
 
 Bundle-Description = A test case for Promises.
 

--- a/org.osgi.test.cases.provisioning/bnd.bnd
+++ b/org.osgi.test.cases.provisioning/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -make                   =  \
   (*).(jar);                             type=bnd;  recipe="bnd/$1.bnd", \

--- a/org.osgi.test.cases.pushstream/bnd.bnd
+++ b/org.osgi.test.cases.pushstream/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd, ${build}/cmpn.bnd
 
 Bundle-Description = A test case for PushStreams.
 

--- a/org.osgi.test.cases.remoteserviceadmin.secure/bnd.bnd
+++ b/org.osgi.test.cases.remoteserviceadmin.secure/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description					: Remote Service Admin secure test cases.
 Bundle-Vendor: TIBCO Software Inc.

--- a/org.osgi.test.cases.remoteserviceadmin/bnd.bnd
+++ b/org.osgi.test.cases.remoteserviceadmin/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description					: Remote Service Admin test cases.
 

--- a/org.osgi.test.cases.remoteservices/bnd.bnd
+++ b/org.osgi.test.cases.remoteservices/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description					: Remote Services test cases.
 

--- a/org.osgi.test.cases.repository/bnd.bnd
+++ b/org.osgi.test.cases.repository/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/osgi.ct.promise.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage                 = org.osgi.test.support.*
 -privatepackage                     =  \

--- a/org.osgi.test.cases.residentialmanagement/bnd.bnd
+++ b/org.osgi.test.cases.residentialmanagement/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.resolver/bnd.bnd
+++ b/org.osgi.test.cases.resolver/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/core.bnd
 
 Bundle-Description: Tests the Resolver service
 

--- a/org.osgi.test.cases.resourcemonitoring/bnd.bnd
+++ b/org.osgi.test.cases.resourcemonitoring/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description					= Resource Monitoring Test Bundle
 -conditionalpackage					= org.osgi.test.support.*

--- a/org.osgi.test.cases.rest.client.js/bnd.bnd
+++ b/org.osgi.test.cases.rest.client.js/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description = Rest JavaScript Client Service test cases.
 

--- a/org.osgi.test.cases.rest.client/bnd.bnd
+++ b/org.osgi.test.cases.rest.client/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description = Rest Java Client test cases.
 

--- a/org.osgi.test.cases.rest/bnd.bnd
+++ b/org.osgi.test.cases.rest/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description = Rest Service test cases.
 

--- a/org.osgi.test.cases.serial/bnd.bnd
+++ b/org.osgi.test.cases.serial/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.serviceloader.secure/bnd.bnd
+++ b/org.osgi.test.cases.serviceloader.secure/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Secure Test Bundle for ServiceLoader
 

--- a/org.osgi.test.cases.serviceloader/bnd.bnd
+++ b/org.osgi.test.cases.serviceloader/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Test Bundle for ServiceLoader
 

--- a/org.osgi.test.cases.tr069todmt/bnd.bnd
+++ b/org.osgi.test.cases.tr069todmt/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.tracker/bnd.bnd
+++ b/org.osgi.test.cases.tracker/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/core.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.transaction.control.jdbc/bnd.bnd
+++ b/org.osgi.test.cases.transaction.control.jdbc/bnd.bnd
@@ -1,7 +1,7 @@
 javac.profile=compact2
 
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.transaction.control.jpa/bnd.bnd
+++ b/org.osgi.test.cases.transaction.control.jpa/bnd.bnd
@@ -1,7 +1,7 @@
 javac.profile=compact2
 
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.transaction.control/bnd.bnd
+++ b/org.osgi.test.cases.transaction.control/bnd.bnd
@@ -1,7 +1,7 @@
 javac.profile=compact2
 
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.transaction/bnd.bnd
+++ b/org.osgi.test.cases.transaction/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.upnp/bnd.bnd
+++ b/org.osgi.test.cases.upnp/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.url/bnd.bnd
+++ b/org.osgi.test.cases.url/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/core.bnd
 
 Bundle-Description: Tests the URL service control bundle
 

--- a/org.osgi.test.cases.usbinfo/bnd.bnd
+++ b/org.osgi.test.cases.usbinfo/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \

--- a/org.osgi.test.cases.useradmin/bnd.bnd
+++ b/org.osgi.test.cases.useradmin/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Test Bundle for UserAdmin Service tests
 

--- a/org.osgi.test.cases.webcontainer/bnd.bnd
+++ b/org.osgi.test.cases.webcontainer/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -make                   =  \
   (*).(jar);                             type=bnd;  recipe="bnd/$1.bnd", \

--- a/org.osgi.test.cases.wireadmin/bnd.bnd
+++ b/org.osgi.test.cases.wireadmin/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Test Bundle for WireAdmin Service tests
 

--- a/org.osgi.test.cases.xml/bnd.bnd
+++ b/org.osgi.test.cases.xml/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description: Tests the XML service
 

--- a/org.osgi.test.cases.zigbee/bnd.bnd
+++ b/org.osgi.test.cases.zigbee/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 Bundle-Description					= ZigBee Test Bundle
 

--- a/org.osgi.util.converter/bnd.bnd
+++ b/org.osgi.util.converter/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.util.function/bnd.bnd
+++ b/org.osgi.util.function/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/promise.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.util.promise/bnd.bnd
+++ b/org.osgi.util.promise/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/promise.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.util.pushstream/bnd.bnd
+++ b/org.osgi.util.pushstream/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.util.tracker/bnd.bnd
+++ b/org.osgi.util.tracker/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/core.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/org.osgi.util.xml/bnd.bnd
+++ b/org.osgi.util.xml/bnd.bnd
@@ -1,6 +1,6 @@
 javac.profile=compact2
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/osgi.annotation/bnd.bnd
+++ b/osgi.annotation/bnd.bnd
@@ -1,3 +1,6 @@
+# Set javac settings from JDT prefs
+-include : ${build}/eclipse/jdt.bnd, layout.bnd, ${build}/annotation.bnd
+
 Bundle-License: Apache-2.0; \
                 link="https://www.apache.org/licenses/LICENSE-2.0"; \
                 description="Apache License, Version 2.0"
@@ -27,5 +30,4 @@ Require-Capability: osgi.unresolvable; filter:="(&(must.not.resolve=*)(!(must.no
 -buildpath = \
     ${replace;${osgi.annotation.specs};$;\\;version=project}
 
--include : ${build}/eclipse/jdt.bnd, layout.bnd
 javadoc.title = Annotation

--- a/osgi.annotation/layout.bnd
+++ b/osgi.annotation/layout.bnd
@@ -1,7 +1,8 @@
-osgi.annotation.specs = \
-    org.osgi.annotation.versioning, \
-    org.osgi.annotation.bundle
+osgi.annotation.projects: ${sort;${filterout;${projectswhere;packaging;*annotation*};org\\.osgi\\.(impl|test)\\..*|osgi\\..*}}
 
-osgi.annotation.packages = ${replace;${osgi.annotation.specs};$;.*}
+osgi.annotation.specs: ${osgi.annotation.projects}
 
-osgi.annotation.resources = {${project.workspace}/osgi.companion/legal/jar}
+osgi.annotation.packages: ${replace;${osgi.annotation.specs};$;.*}
+
+osgi.annotation.resources: \
+ {${project.workspace}/osgi.companion/legal/jar}

--- a/osgi.cmpn/bnd.bnd
+++ b/osgi.cmpn/bnd.bnd
@@ -1,3 +1,6 @@
+# Set javac settings from JDT prefs
+-include : ${build}/eclipse/jdt.bnd, layout.bnd, ${build}/cmpn.bnd
+
 Bundle-License: Apache-2.0; \
                 link="https://www.apache.org/licenses/LICENSE-2.0"; \
                 description="Apache License, Version 2.0"
@@ -39,5 +42,4 @@ Require-Capability: osgi.unresolvable; filter:="(&(must.not.resolve=*)(!(must.no
     com.icl.saxon;version=latest
 -fixupmessages.jpa_spec: Version for package org\.osgi\.service\.jpa is set to different values
 
--include : ${build}/eclipse/jdt.bnd, layout.bnd
 javadoc.title = Compendium

--- a/osgi.cmpn/layout.bnd
+++ b/osgi.cmpn/layout.bnd
@@ -1,64 +1,14 @@
-osgi.cmpn.specs = \
-     org.osgi.jmx, \
-     org.osgi.namespace.contract, \
-     org.osgi.namespace.extender, \
-     org.osgi.namespace.implementation, \
-     org.osgi.namespace.service, \
-     org.osgi.namespace.unresolvable, \
-     org.osgi.service.async, \
-     org.osgi.service.cdi, \
-     org.osgi.service.clusterinfo, \
-     org.osgi.service.cm, \
-     org.osgi.service.component, \
-     org.osgi.service.component.annotations, \
-     org.osgi.service.conditionfactory, \
-     org.osgi.service.configurator, \
-     org.osgi.service.coordinator, \
-     org.osgi.service.dal, \
-     org.osgi.service.dal.functions, \
-     org.osgi.service.device, \
-     org.osgi.service.dmt, \
-     org.osgi.service.enocean, \
-     org.osgi.service.event, \
-     org.osgi.service.http, \
-     org.osgi.service.http.whiteboard, \
-     org.osgi.service.jaxrs, \
-     org.osgi.service.jdbc, \
-     org.osgi.service.jndi, \
-     org.osgi.service.jpa, \
-     org.osgi.service.log.stream, \
-     org.osgi.service.metatype, \
-     org.osgi.service.metatype.annotations, \
-     org.osgi.service.networkadapter, \
-     org.osgi.service.onem2m, \
-     org.osgi.service.prefs, \
-     org.osgi.service.provisioning, \
-     org.osgi.service.remoteserviceadmin, \
-     org.osgi.service.repository, \
-     org.osgi.service.resourcemonitoring, \
-     org.osgi.service.rest, \
-     org.osgi.service.serial, \
-     org.osgi.service.serviceloader, \
-     org.osgi.service.tr069todmt, \
-     org.osgi.service.transaction.control, \
-     org.osgi.service.typedevent, \
-     org.osgi.service.upnp, \
-     org.osgi.service.usbinfo, \
-     org.osgi.service.useradmin, \
-     org.osgi.service.wireadmin, \
-     org.osgi.service.zigbee, \
-     org.osgi.util.converter, \
-     org.osgi.util.function, \
-     org.osgi.util.promise, \
-     org.osgi.util.pushstream, \
-     org.osgi.util.xml
+osgi.cmpn.projects: ${sort;${filterout;${projectswhere;packaging;*cmpn*};org\\.osgi\\.(impl|test)\\..*|osgi\\..*}}
 
-osgi.cmpn.packages = ${replace;${osgi.cmpn.specs};$;.*}
+osgi.cmpn.specs: ${osgi.cmpn.projects}
 
-osgi.cmpn.resources = {${project.workspace}/osgi.companion/legal/jar}, \
-                xmlns/app=${project.workspace}/xmlns/app, \
-                xmlns/metatype=${project.workspace}/xmlns/metatype, \
-                xmlns/rsa=${project.workspace}/xmlns/rsa, \
-                xmlns/repository=${project.workspace}/xmlns/repository, \
-                xmlns/rest=${project.workspace}/xmlns/rest, \
-                xmlns/scr=${project.workspace}/xmlns/scr
+osgi.cmpn.packages: ${replace;${osgi.cmpn.specs};$;.*}
+
+osgi.cmpn.resources: \
+ {${project.workspace}/osgi.companion/legal/jar}, \
+ xmlns/app=${project.workspace}/xmlns/app, \
+ xmlns/metatype=${project.workspace}/xmlns/metatype, \
+ xmlns/rsa=${project.workspace}/xmlns/rsa, \
+ xmlns/repository=${project.workspace}/xmlns/repository, \
+ xmlns/rest=${project.workspace}/xmlns/rest, \
+ xmlns/scr=${project.workspace}/xmlns/scr

--- a/osgi.companion/layout.bnd
+++ b/osgi.companion/layout.bnd
@@ -1,13 +1,14 @@
-osgi.companion.jars =\
-  osgi.annotation,\
-  osgi.core,\
-  osgi.cmpn,\
-  osgi.promise
+osgi.companion.jars: \
+ osgi.annotation,\
+ osgi.core,\
+ osgi.cmpn,\
+ osgi.promise
 
 # The includes below must match the list above
--include: ${project.workspace}/osgi.annotation/layout.bnd, \
-	${project.workspace}/osgi.core/layout.bnd, \
-	${project.workspace}/osgi.cmpn/layout.bnd, \
-	${project.workspace}/osgi.promise/layout.bnd
+-include: \
+ ${project.workspace}/osgi.annotation/layout.bnd,\
+ ${project.workspace}/osgi.core/layout.bnd,\
+ ${project.workspace}/osgi.cmpn/layout.bnd,\
+ ${project.workspace}/osgi.promise/layout.bnd
 
-osgi.companion.specs = ${uniq;${map;def;${replace;${osgi.companion.jars};$;.specs}}}
+osgi.companion.specs: ${uniq;${map;def;${replace;${osgi.companion.jars};$;.specs}}}

--- a/osgi.core/bnd.bnd
+++ b/osgi.core/bnd.bnd
@@ -1,3 +1,6 @@
+# Set javac settings from JDT prefs
+-include : ${build}/eclipse/jdt.bnd, layout.bnd, ${build}/core.bnd
+
 Automatic-Module-Name: ${bsn}
 Bundle-License: Apache-2.0; \
                 link="https://www.apache.org/licenses/LICENSE-2.0"; \
@@ -31,5 +34,4 @@ Require-Capability: osgi.unresolvable; filter:="(&(must.not.resolve=*)(!(must.no
 	${replace;${osgi.core.specs};$;\\;version=project}, \
 	osgi.annotation;maven-scope=provided;version=${osgi.annotation.version}
 
--include : ${build}/eclipse/jdt.bnd, layout.bnd
 javadoc.title = Core

--- a/osgi.core/layout.bnd
+++ b/osgi.core/layout.bnd
@@ -1,17 +1,8 @@
-osgi.core.specs = \
- org.osgi.dto, \
- org.osgi.framework, \
- org.osgi.resource, \
- org.osgi.service.condition, \
- org.osgi.service.condpermadmin, \
- org.osgi.service.log, \
- org.osgi.service.packageadmin, \
- org.osgi.service.permissionadmin, \
- org.osgi.service.resolver, \
- org.osgi.service.startlevel, \
- org.osgi.service.url, \
- org.osgi.util.tracker
+osgi.core.projects: ${sort;${filterout;${projectswhere;packaging;*core*};org\\.osgi\\.(impl|test)\\..*|osgi\\..*}}
 
-osgi.core.packages = ${replace;${osgi.core.specs};$;.*}
+osgi.core.specs: ${osgi.core.projects}
 
-osgi.core.resources = {${project.workspace}/osgi.companion/legal/jar}
+osgi.core.packages: ${replace;${osgi.core.specs};$;.*}
+
+osgi.core.resources: \
+ {${project.workspace}/osgi.companion/legal/jar}

--- a/osgi.ct/cmpn.bnd
+++ b/osgi.ct/cmpn.bnd
@@ -1,3 +1,5 @@
+-include: ${build}/cmpn.bnd
+
 Bundle-Description: OSGi Compendium Release ${versionmask;=;${build.version}} Compliance Tests
 
 -resourceonly: true

--- a/osgi.ct/core.bnd
+++ b/osgi.ct/core.bnd
@@ -1,3 +1,5 @@
+-include: ${build}/core.bnd
+
 Bundle-Description: OSGi Core Release ${versionmask;=;${build.version}} Compliance Tests
 
 -resourceonly: true

--- a/osgi.ct/layout.bnd
+++ b/osgi.ct/layout.bnd
@@ -1,100 +1,20 @@
-build.tests                 = ${uniq; org.osgi.test.filter, ${build.core.tests}, ${build.cmpn.tests}}
+build.tests: ${uniq;org.osgi.test.filter,${build.core.tests},${build.cmpn.tests}}
 
-jar.core.tests = \
-    ${repo;org.apache.servicemix.bundles.bcel;latest}, \
+osgi.core.projects: ${sort;${filter;${projectswhere;packaging;*core*};org\\.osgi\\.test\\..*}}
+osgi.cmpn.projects: ${sort;${filter;${projectswhere;packaging;*cmpn*};org\\.osgi\\.test\\..*}}
+
+jar.core.tests: \
+    ${repo;org.apache.servicemix.bundles.bcel;latest},\
     ${repo;org.osgi.impl.service.cm;latest},\
     ${repo;osgi.ct.junit-platform;latest}
 
-build.core.tests = \
-    org.osgi.test.cases.bundle.annotations, \
-    org.osgi.test.cases.condpermadmin, \
-    org.osgi.test.cases.framework, \
-    org.osgi.test.cases.framework.secure, \
-    org.osgi.test.cases.framework.launch, \
-    org.osgi.test.cases.framework.launch.secure, \
-    org.osgi.test.cases.log, \
-    org.osgi.test.cases.log.launch, \
-    org.osgi.test.cases.permissionadmin, \
-    org.osgi.test.cases.resolver, \
-    org.osgi.test.cases.tracker, \
-    org.osgi.test.cases.url
+build.core.tests: ${osgi.core.projects}
 
-jar.cmpn.tests = \
-    ${repo;org.osgi.impl.service.jdbc.support;latest}, \
-    ${repo;org.osgi.impl.service.rest.support;latest}, \
+jar.cmpn.tests: \
+    ${repo;org.osgi.impl.service.jdbc.support;latest},\
+    ${repo;org.osgi.impl.service.rest.support;latest},\
     ${repo;org.osgi.test.filter;latest},\
     ${repo;osgi.ct.junit-platform;latest},\
     ${repo;osgi.ct.promise;latest}
 
-build.cmpn.tests = \
-    org.osgi.test.cases.async, \
-    org.osgi.test.cases.async.secure, \
-    org.osgi.test.cases.cdi, \
-    org.osgi.test.cases.cdi.secure, \
-    org.osgi.test.cases.clusterinfo, \
-    org.osgi.test.cases.clusterinfo.secure, \
-    org.osgi.test.cases.cm, \
-    org.osgi.test.cases.component, \
-    org.osgi.test.cases.component.annotations, \
-    org.osgi.test.cases.configurator, \
-    org.osgi.test.cases.configurator.secure, \
-    org.osgi.test.cases.converter, \
-    org.osgi.test.cases.coordinator, \
-    org.osgi.test.cases.coordinator.secure, \
-    org.osgi.test.cases.dal, \
-    org.osgi.test.cases.dal.functions, \
-    org.osgi.test.cases.dal.secure, \
-    org.osgi.test.cases.device, \
-    org.osgi.test.cases.dmt.tc1, \
-    org.osgi.test.cases.dmt.tc2, \
-    org.osgi.test.cases.dmt.tc3, \
-    org.osgi.test.cases.dmt.tc4, \
-    org.osgi.test.cases.enocean, \
-    org.osgi.test.cases.event, \
-    org.osgi.test.cases.event.secure, \
-    org.osgi.test.cases.http, \
-    org.osgi.test.cases.http.whiteboard, \
-    org.osgi.test.cases.http.whiteboard.secure, \
-    org.osgi.test.cases.jaxrs, \
-    org.osgi.test.cases.jdbc, \
-    org.osgi.test.cases.jmx.cm, \
-    org.osgi.test.cases.jmx.framework, \
-    org.osgi.test.cases.jmx.framework.secure, \
-    org.osgi.test.cases.jmx.provisioning, \
-    org.osgi.test.cases.jmx.useradmin, \
-    org.osgi.test.cases.jndi, \
-    org.osgi.test.cases.jndi.secure, \
-    org.osgi.test.cases.jpa, \
-    org.osgi.test.cases.log.stream, \
-    org.osgi.test.cases.metatype, \
-    org.osgi.test.cases.metatype.annotations, \
-    org.osgi.test.cases.networkadapter, \
-    org.osgi.test.cases.onem2m, \
-    org.osgi.test.cases.prefs, \
-    org.osgi.test.cases.promise, \
-    org.osgi.test.cases.provisioning, \
-    org.osgi.test.cases.pushstream, \
-    org.osgi.test.cases.remoteserviceadmin, \
-    org.osgi.test.cases.remoteserviceadmin.secure, \
-    org.osgi.test.cases.remoteservices, \
-    org.osgi.test.cases.repository, \
-    org.osgi.test.cases.residentialmanagement, \
-    org.osgi.test.cases.resourcemonitoring, \
-    org.osgi.test.cases.rest, \
-    org.osgi.test.cases.rest.client, \
-    org.osgi.test.cases.rest.client.js, \
-    org.osgi.test.cases.serial, \
-    org.osgi.test.cases.serviceloader, \
-    org.osgi.test.cases.serviceloader.secure, \
-    org.osgi.test.cases.tr069todmt, \
-    org.osgi.test.cases.transaction, \
-    org.osgi.test.cases.transaction.control, \
-    org.osgi.test.cases.transaction.control.jdbc, \
-    org.osgi.test.cases.transaction.control.jpa, \
-    org.osgi.test.cases.upnp, \
-    org.osgi.test.cases.usbinfo, \
-    org.osgi.test.cases.useradmin, \
-    org.osgi.test.cases.webcontainer, \
-    org.osgi.test.cases.wireadmin, \
-    org.osgi.test.cases.xml, \
-    org.osgi.test.cases.zigbee
+build.cmpn.tests: ${osgi.cmpn.projects}

--- a/osgi.promise/bnd.bnd
+++ b/osgi.promise/bnd.bnd
@@ -1,3 +1,6 @@
+# Set javac settings from JDT prefs
+-include : ${build}/eclipse/jdt.bnd, layout.bnd, ${build}/promise.bnd
+
 Automatic-Module-Name: ${bsn}
 Bundle-License: Apache-2.0; \
                 link="https://www.apache.org/licenses/LICENSE-2.0"; \
@@ -24,5 +27,4 @@ Export-Package: ${osgi.promise.packages}
 -buildpath = ${replace;${osgi.promise.specs};$;\\;version=project}, \
     osgi.annotation;maven-scope=provided;version=${osgi.annotation.version}
 
--include = ${build}/eclipse/jdt.bnd, layout.bnd
 javadoc.title = Promise

--- a/osgi.promise/layout.bnd
+++ b/osgi.promise/layout.bnd
@@ -1,7 +1,8 @@
-osgi.promise.specs = \
-    org.osgi.util.promise, \
-    org.osgi.util.function
+osgi.promise.projects: ${sort;${filterout;${projectswhere;packaging;*promise*};org\\.osgi\\.(impl|test)\\..*|osgi\\..*}}
 
-osgi.promise.packages = ${replace;${osgi.promise.specs};$;.*}
+osgi.promise.specs: ${osgi.promise.projects}
 
-osgi.promise.resources = {${project.workspace}/osgi.companion/legal/jar}
+osgi.promise.packages: ${replace;${osgi.promise.specs};$;.*}
+
+osgi.promise.resources: \
+ {${project.workspace}/osgi.companion/legal/jar}

--- a/osgi.ri/cmpn.bnd
+++ b/osgi.ri/cmpn.bnd
@@ -1,3 +1,5 @@
+-include: ${build}/cmpn.bnd
+
 Bundle-Description: OSGi Compendium Release ${versionmask;=;${build.version}} Reference Implementations
 
 -resourceonly: true

--- a/osgi.ri/core.bnd
+++ b/osgi.ri/core.bnd
@@ -1,3 +1,5 @@
+-include: ${build}/core.bnd
+
 Bundle-Description: OSGi Core Release ${versionmask;=;${build.version}} Reference Implementation
 
 -resourceonly: true

--- a/osgi.ri/layout.bnd
+++ b/osgi.ri/layout.bnd
@@ -1,76 +1,49 @@
-build.impls                 = ${uniq; ${build.core.impls}, ${build.cmpn.impls}}
+build.impls: ${uniq;${build.core.impls},${build.cmpn.impls}}
 
-build.core.impls = \
-    org.osgi.dto, \
-    org.osgi.util.tracker, \
-	org.osgi.impl.bundle.annotations
+osgi.core.projects: ${sort;${filter;${projectswhere;packaging;*core*};org\\.osgi\\.impl\\..*}}
+osgi.cmpn.projects: ${sort;${filter;${projectswhere;packaging;*cmpn*};org\\.osgi\\.impl\\..*}}
 
-jar.core.impls = \
-	${repo;org.osgi.impl.framework;latest}, \
-    ${repo;org.osgi.impl.service.log;latest}, \
+build.core.impls: \
+    org.osgi.dto,\
+    org.osgi.util.tracker,\
+	${osgi.core.projects}
+
+jar.core.impls: \
+	${repo;org.osgi.impl.framework;latest},\
+    ${repo;org.osgi.impl.service.log;latest},\
     ${repo;org.osgi.impl.service.resolver;latest}
 
-build.cmpn.impls = \
-	org.osgi.impl.bundle.annotations, \
-	org.osgi.impl.bundle.component.annotations, \
-	org.osgi.impl.bundle.jaxp, \
-	org.osgi.impl.bundle.metatype.annotations, \
-	org.osgi.impl.bundle.rsh, \
-	org.osgi.impl.bundle.transaction, \
-    org.osgi.impl.service.async, \
-    org.osgi.impl.service.dal, \
-    org.osgi.impl.service.dal.step, \
-	org.osgi.impl.service.device.manager, \
-	org.osgi.impl.service.dmt, \
-	org.osgi.impl.service.enocean, \
-	org.osgi.impl.service.jdbc, \
-	org.osgi.impl.service.jndi, \
-	org.osgi.impl.service.networkadapter, \
-	org.osgi.service.onem2m, \
-	org.osgi.impl.service.onem2m, \
-	org.osgi.impl.service.prefs, \
-	org.osgi.impl.service.residentialmanagement, \
-	org.osgi.impl.service.resourcemonitoring, \
-	org.osgi.impl.service.resourcemonitoring.fakemonitors, \
-	org.osgi.impl.service.resourcemonitoring.util, \
-	org.osgi.impl.service.rest, \
-	org.osgi.impl.service.rest.client, \
-	org.osgi.impl.service.rest.client.js, \
-	org.osgi.impl.service.serial, \
-	org.osgi.impl.service.tr069todmt, \
-	org.osgi.impl.service.upnp.cp, \
-	org.osgi.impl.service.upnp.cd, \
-	org.osgi.impl.service.usbinfo, \
-	org.osgi.impl.service.useradmin, \
-	org.osgi.impl.service.zigbee, \
-    org.osgi.util.converter, \
-    org.osgi.util.function, \
-    org.osgi.util.promise, \
-    org.osgi.util.pushstream, \
-    org.osgi.util.xml
+build.cmpn.impls: \
+	org.osgi.service.onem2m,\
+    org.osgi.util.converter,\
+    org.osgi.util.function,\
+    org.osgi.util.promise,\
+    org.osgi.util.pushstream,\
+    org.osgi.util.xml,\
+    ${osgi.cmpn.projects}
 
-jar.cmpn.impls = \
-	${repo;org.osgi.impl.bundle.cdi;latest}, \
-	${repo;org.osgi.impl.bundle.derby;latest}, \
-	${repo;org.osgi.impl.bundle.jmx;latest}, \
-	${repo;org.osgi.impl.bundle.serviceloader;latest}, \
-	${repo;org.osgi.impl.bundle.webcontainer;latest}, \
-	${repo;org.osgi.impl.service.clusterinfo;latest}, \
-	${repo;org.osgi.impl.service.cm;latest}, \
-	${repo;org.osgi.impl.service.component;latest}, \
-	${repo;org.osgi.impl.service.configurator;latest}, \
-	${repo;org.osgi.impl.service.coordinator;latest}, \
-	${repo;org.osgi.impl.service.event;latest}, \
-	${repo;org.osgi.impl.service.http;latest}, \
-	${repo;org.osgi.impl.service.http.whiteboard;latest}, \
-	${repo;org.osgi.impl.service.jaxrs;latest}, \
-	${repo;org.osgi.impl.service.jpa;latest}, \
-	${repo;org.osgi.impl.service.log.stream;latest}, \
-	${repo;org.osgi.impl.service.metatype;latest}, \
-	${repo;org.osgi.impl.service.provisioning;latest}, \
-	${repo;org.osgi.impl.service.remoteserviceadmin;latest}, \
-    ${repo;org.osgi.impl.service.repository;latest}, \
-	${repo;org.osgi.impl.service.transaction.control;latest}, \
-	${repo;org.osgi.impl.service.transaction.control.jdbc;latest}, \
-	${repo;org.osgi.impl.service.transaction.control.jpa;latest}, \
+jar.cmpn.impls: \
+	${repo;org.osgi.impl.bundle.cdi;latest},\
+	${repo;org.osgi.impl.bundle.derby;latest},\
+	${repo;org.osgi.impl.bundle.jmx;latest},\
+	${repo;org.osgi.impl.bundle.serviceloader;latest},\
+	${repo;org.osgi.impl.bundle.webcontainer;latest},\
+	${repo;org.osgi.impl.service.clusterinfo;latest},\
+	${repo;org.osgi.impl.service.cm;latest},\
+	${repo;org.osgi.impl.service.component;latest},\
+	${repo;org.osgi.impl.service.configurator;latest},\
+	${repo;org.osgi.impl.service.coordinator;latest},\
+	${repo;org.osgi.impl.service.event;latest},\
+	${repo;org.osgi.impl.service.http;latest},\
+	${repo;org.osgi.impl.service.http.whiteboard;latest},\
+	${repo;org.osgi.impl.service.jaxrs;latest},\
+	${repo;org.osgi.impl.service.jpa;latest},\
+	${repo;org.osgi.impl.service.log.stream;latest},\
+	${repo;org.osgi.impl.service.metatype;latest},\
+	${repo;org.osgi.impl.service.provisioning;latest},\
+	${repo;org.osgi.impl.service.remoteserviceadmin;latest},\
+    ${repo;org.osgi.impl.service.repository;latest},\
+	${repo;org.osgi.impl.service.transaction.control;latest},\
+	${repo;org.osgi.impl.service.transaction.control.jdbc;latest},\
+	${repo;org.osgi.impl.service.transaction.control.jpa;latest},\
 	${repo;org.osgi.impl.service.wireadmin;latest}

--- a/templates/org.osgi.impl.service.template/bnd.bnd
+++ b/templates/org.osgi.impl.service.template/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/cmpn.bnd
 
 Bundle-Activator			= org.osgi.impl.service.template.Activator
 Bundle-Description			= Template for a Reference Implementation.

--- a/templates/org.osgi.service.template/bnd.bnd
+++ b/templates/org.osgi.service.template/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/companion.bnd, ${build}/cmpn.bnd
 
 Export-Package: ${p}.*; -split-package:=first
 

--- a/templates/org.osgi.test.cases.template/bnd.bnd
+++ b/templates/org.osgi.test.cases.template/bnd.bnd
@@ -1,5 +1,5 @@
 # Set javac settings from JDT prefs
--include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd
+-include: ${build}/eclipse/jdt.bnd, ${build}/osgi.ct.junit-platform.bnd, ${build}/cmpn.bnd
 
 -conditionalpackage					= org.osgi.test.support.*
 -privatepackage						=  \


### PR DESCRIPTION
The build will use a project's packaging type to include it into the
proper build artifacts.

The packaging include files also allow use to build different
packaging types with different attributes such as versions. This will
be used to build annotation and core as final while cmpn and promise are
still snapshot.