### PR TITLE
spec: Fix html draft watermark to avoid reference to missing image

### DIFF
--- a/osgi.specs/build.gradle
+++ b/osgi.specs/build.gradle
@@ -264,7 +264,7 @@ books.forEach { book ->
           param('name': 'copyright.year', 'expression': "2000, ${copyright_year}")
           param('name': 'draft.mode', 'expression': booktask.get().draftmode)
           if (booktask.get().draftmode != 'no') {
-            param('name': 'draft.watermark.image', 'expression': "${watermark}.png")
+            param('name': 'draft.watermark.image', 'expression': "images/${watermark}.png")
           }
           param('name': 'webhelp.base.dir', 'expression': file(destinationDirectory))
           param('name': 'webhelp.default.topic', 'expression': 'index.html')

--- a/osgi.specs/docbook/xsl/custom-html-common.xsl
+++ b/osgi.specs/docbook/xsl/custom-html-common.xsl
@@ -72,6 +72,19 @@
 </xsl:template>
 
 <!-- HTML <head> section customizations -->
+<xsl:template name="head.content.style">
+  <xsl:param name="node" select="."/>
+  <style type="text/css">
+    <xsl:text>
+#scrollable {
+    background: transparent url('</xsl:text><xsl:value-of select="$draft.watermark.image"/><xsl:text>') repeat-y center top;
+    background-attachment: local;
+    background-size: 120%;
+}
+    </xsl:text>
+  </style>
+</xsl:template>
+
 <xsl:template name="user.head.content">
     <xsl:param name="title">
         <xsl:apply-templates select="." mode="object.title.markup.textonly"/>
@@ -86,16 +99,6 @@
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Ubuntu:regular,bold&amp;subset=Latin" />
     <script type="text/javascript" src="js/highlight.pack.js"></script>
     <script type="text/javascript" src="js/main.js"></script>
-
-    <xsl:if test="$draft.mode != 'no'">
-      <style>
-        <xsl:text><![CDATA[#scrollable {
-    background: transparent url(images/]]></xsl:text><xsl:value-of select="$draft.watermark.image"/><xsl:text><![CDATA[) repeat-y center top;
-    background-attachment: local;
-    background-size: 120%;
-}]]></xsl:text>
-      </style>
-    </xsl:if>
 </xsl:template>
 
 <xsl:template match="/">


### PR DESCRIPTION
The html draft watermark did not replace the default watermark in the
generated html. It had just added more css. The original css referenced
a missing image.

The stylesheet is fixed to replace the default watermark css with our
custom watermark css.