### PR TITLE
 servicetracker: Use nanoTime values for timeout computations

### DIFF
--- a/org.osgi.util.tracker/src/org/osgi/util/tracker/package-info.java
+++ b/org.osgi.util.tracker/src/org/osgi/util/tracker/package-info.java
@@ -29,7 +29,7 @@
  * @author $Id$
  */
 
-@Version("1.5.3")
+@Version("1.5.4")
 package org.osgi.util.tracker;
 
 import org.osgi.annotation.versioning.Version;

--- a/osgi.specs/docbook/112/service.component.xml
+++ b/osgi.specs/docbook/112/service.component.xml
@@ -534,7 +534,7 @@
 
       <para>The component class looks like:</para>
 
-      <programlisting>public class USBConnectionImpl implements USBConnection {
+      <programlisting>public class USBConnectionImpl {
     private void activate(Map&lt;String, ?&gt; properties) {
      ...
     }


### PR DESCRIPTION
We avoid currentTimeMillis as it can change as the system clock is
changed. nanoTime only changes with the advancement of time.

Fixes #148

