### PR TITLE
ci: Move draft specification publication to osgi repo

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -107,11 +107,10 @@ jobs:
       run: |
         ./.github/scripts/spec.sh
     - name: Publish Specification HTML  
-      if: ${{ env.canonical == 'true' }}
+      if: ${{ (env.canonical == 'true') || ((github.repository != 'osgi/osgi') && (github.event_name != 'pull_request')) }}
       uses: peaceiris/actions-gh-pages@v3
       with:
-        deploy_key: ${{ secrets.DRAFT_DEPLOY_KEY }}
-        external_repository: osgi/draft
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
         publish_dir: osgi.specs/generated/html
         force_orphan: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSGi
 
-This is the main git repository for the OSGi specifications, reference implementations and compliance tests. It is a Bnd Workspace model build.
+This is the main git repository for the OSGi specifications, implementations and TCKs. It is a Bnd Workspace model build.
 
 ## Build
 
@@ -8,6 +8,11 @@ See [CONTRIBUTING](CONTRIBUTING.md) for information on checking out the repo and
 
 ## Draft Specifications
 
-The latest draft specifications can be viewed at:
-- [Core](https://osgi.github.io/draft/core/)
-- [Compendium](https://osgi.github.io/draft/cmpn/)
+The GitHub Actions build "Specification" job will publish the draft specifications into the repo's `gh-pages` branch. So you can  view the draft specifications for the `osgi/osgi` repo:
+
+- [Core](https://osgi.github.io/osgi/core/)
+- [Compendium](https://osgi.github.io/osgi/cmpn/)
+
+In your fork, just add `core/` or `cmpn/` to the end of your fork's GitHub Pages URL. For example:
+
+> https://&lt;username&gt;.github.io/osgi/core/


### PR DESCRIPTION
Since osgi repo is now public, we now no longer need a separate public
draft repo to publish spec drafts.