### PR TITLE
spec: Refactor copyright year into profile xsl

### DIFF
--- a/osgi.specs/build.gradle
+++ b/osgi.specs/build.gradle
@@ -122,6 +122,7 @@ books.forEach { book ->
       ext.bookxml = destinationDirectory.file(name)
       def stylesheet = file('docbook/xsl/custom-profile.xsl')
       def watermark = bnd("${book}.draft", 'no')
+      def copyrightyear = "2000, ${bnd('copyright.year')}"
       ext.draftmode = (watermark != 'no') ? 'yes' : 'no'
       inputs.files stylesheet, fileTree('dir': 'docbook', 'include': '**/*.xml'), sourceSets.main.runtimeClasspath
       inputs.files javadoc, xmlns
@@ -129,6 +130,7 @@ books.forEach { book ->
         inputs.files rdmtsummary
       }
       inputs.property 'draft.mode', draftmode
+      inputs.property 'copyright.year', copyrightyear
 
       outputs.file bookxml
       doFirst {
@@ -150,6 +152,7 @@ books.forEach { book ->
           }
           factory('name': 'com.icl.saxon.TransformerFactoryImpl')
           param('name': 'draft.mode', 'expression': draftmode)
+          param('name': 'copyright.year', 'expression': copyrightyear)
         }
         javaexec {
           classpath sourceSets.main.runtimeClasspath
@@ -257,7 +260,6 @@ books.forEach { book ->
       def htmlResources = file('docbook/xsl/html-resources')
       def licensedResources = file("${bnd.licensed}/webresources")
       def watermark = bnd("${book}.draft", 'no')
-      def copyright_year = bnd('copyright.year')
       def release_version = bnd('osgi.release')
       ext.destinationDirectory = project.objects.directoryProperty().value(project.layout.buildDirectory.dir("html/${book}"))
 
@@ -265,7 +267,6 @@ books.forEach { book ->
       inputs.dir htmlResources
       inputs.dir licensedResources
       inputs.property 'watermark', watermark
-      inputs.property 'copyright_year', copyright_year
       inputs.property 'release_version', release_version
       outputs.dir destinationDirectory
 
@@ -279,7 +280,6 @@ books.forEach { book ->
           'out': new File(temporaryDir, 'book.txt')) {
           classpath('location': bnd.saxon)
           factory('name': 'com.icl.saxon.TransformerFactoryImpl')
-          param('name': 'copyright.year', 'expression': "2000, ${copyright_year}")
           param('name': 'draft.mode', 'expression': booktask.get().draftmode)
           if (booktask.get().draftmode != 'no') {
             param('name': 'draft.watermark.image', 'expression': "images/${watermark}.png")
@@ -336,11 +336,9 @@ private Closure fotaskConfiguration(bookName, xmltask) {
       ext.bookfo = destinationDirectory.file(name)
       def stylesheet = file('docbook/xsl/custom-fo.xsl')
       def watermark = bnd("${bookName}.draft", 'no')
-      def copyright_year = bnd('copyright.year')
 
       inputs.files xmltask, stylesheet
       inputs.property 'watermark', watermark
-      inputs.property 'copyright_year', copyright_year
       outputs.file bookfo
       doFirst {
         project.mkdir(destinationDirectory)
@@ -355,7 +353,6 @@ private Closure fotaskConfiguration(bookName, xmltask) {
           if (xmltask.get().draftmode != 'no') {
             param('name': 'draft.watermark.image', 'expression': "docbook/graphics/${watermark}.svg")
           }
-          param('name': 'copyright.year', 'expression': "2000, ${copyright_year}")
         }
       }
     }

--- a/osgi.specs/docbook/xsl/custom-fo.xsl
+++ b/osgi.specs/docbook/xsl/custom-fo.xsl
@@ -51,9 +51,6 @@ book toc,title
 <xsl:param name="page.width.portrait">18.898cm</xsl:param>
 <xsl:param name="draft.mode">yes</xsl:param>
 <xsl:param name="draft.watermark.image">../graphics/draft.svg</xsl:param>
-<xsl:param name="copyright.year">
-  <xsl:value-of select="/d:book/d:info/d:copyright/d:year"/>
-</xsl:param>
 <xsl:param name="fop1.extensions" select="1"/>
 <xsl:param name="xep.extensions" select="0"/>
 <xsl:param name="front.logo.image">../graphics/OSGi_Alliance.svg</xsl:param>
@@ -2058,7 +2055,11 @@ should be discarded -->
   <fo:block xsl:use-attribute-sets="verso.properties">
     <fo:block xsl:use-attribute-sets="verso.copyright.properties">
       <xsl:text>Copyright &#xA9; </xsl:text>
-      <xsl:value-of select="$copyright.year"/>
+      <xsl:call-template name="copyright.years">
+        <xsl:with-param name="years" select="d:info/d:copyright/d:year"/>
+        <xsl:with-param name="print.ranges" select="$make.year.ranges"/>
+        <xsl:with-param name="single.year.ranges" select="$make.single.year.ranges"/>
+      </xsl:call-template>
       <xsl:text> </xsl:text>
       <xsl:value-of select="d:info/d:copyright/d:holder"/>
     </fo:block>

--- a/osgi.specs/docbook/xsl/custom-html.xsl
+++ b/osgi.specs/docbook/xsl/custom-html.xsl
@@ -54,9 +54,6 @@ parent::d:tasksummary|parent::d:warning|parent::d:topic">
 
 <xsl:param name="draft.mode">yes</xsl:param>
 <xsl:param name="draft.watermark.image">draft.png</xsl:param>
-<xsl:param name="copyright.year">
-  <xsl:value-of select="/d:book/d:info/d:copyright/d:year"/>
-</xsl:param>
 
 <xsl:param name="autotoc.label.separator" select="'&#160;'" />
 <xsl:param name="description.bullet" select="'&#x25A1;'" />
@@ -778,16 +775,5 @@ example before
     </xsl:message>
   </xsl:if>
 </xsl:template>
-
-  <xsl:template match="d:copyright" mode="titlepage.mode">
-    <p>
-      <xsl:apply-templates select="." mode="common.html.attributes"/>
-      <xsl:call-template name="id.attribute"/>
-      <xsl:text>Copyright &#xA9; </xsl:text>
-      <xsl:value-of select="$copyright.year"/>
-      <xsl:text> </xsl:text>
-      <xsl:apply-templates select="d:holder" mode="titlepage.mode"/>
-    </p>
-  </xsl:template>
 
 </xsl:stylesheet>

--- a/osgi.specs/docbook/xsl/custom-profile.xsl
+++ b/osgi.specs/docbook/xsl/custom-profile.xsl
@@ -3,7 +3,6 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
   xmlns:exsl="http://exslt.org/common"
   xmlns:d="http://docbook.org/ns/docbook"
-  xmlns:fo="http://www.w3.org/1999/XSL/Format"
   xmlns:xlink='http://www.w3.org/1999/xlink'
   exclude-result-prefixes="exsl"
   version="1.0">
@@ -18,5 +17,16 @@
     <xsl:otherwise>draft</xsl:otherwise>
   </xsl:choose>
 </xsl:param>
+
+<xsl:param name="copyright.year">
+  <xsl:value-of select="/d:book/d:info/d:copyright/d:year"/>
+</xsl:param>
+
+<xsl:template match="/d:book/d:info/d:copyright" mode="profile">
+  <xsl:copy>
+    <xsl:element name="year" namespace="http://docbook.org/ns/docbook"><xsl:value-of select="$copyright.year"/></xsl:element>
+    <xsl:copy-of select="d:holder"/>
+  </xsl:copy>
+</xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Instead of doing the copyright year work in both the fo and html
stylesheets, we refactor into the shared profile stylesheet.
