### PR TITLE
Service Loader test case is not correct

### DIFF
--- a/org.osgi.test.cases.serviceloader/src/org/osgi/test/cases/serviceloader/junit/ServiceLoaderServiceClientTest.java
+++ b/org.osgi.test.cases.serviceloader/src/org/osgi/test/cases/serviceloader/junit/ServiceLoaderServiceClientTest.java
@@ -18,6 +18,8 @@
 
 package org.osgi.test.cases.serviceloader.junit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -213,9 +215,9 @@ public class ServiceLoaderServiceClientTest extends OSGiTestCase {
     				wires = rev.getWiring().getRequiredWires("osgi.serviceloader");
     				assertNotNull(wires);
 
-					assertTrue(
-							"There should be 2 wires as there are 2 providers, but 1 wire is also allowed since cardinality:=multiple is not guaranteed to provide all wires",
-							(wires.size() == 2) || (wires.size() == 1));
+					assertThat(wires).as(
+							"There should be 2 wires as there are 2 providers, but 1 wire is also allowed since cardinality:=multiple is not guaranteed to provide all wires")
+							.hasSizeBetween(1, 2);
 
     				Collection<ServiceReference<TestBridge>> refs = getContext().getServiceReferences(TestBridge.class, "(test=client)");
     				assertNotNull(refs);

--- a/org.osgi.test.cases.serviceloader/src/org/osgi/test/cases/serviceloader/junit/ServiceLoaderServiceClientTest.java
+++ b/org.osgi.test.cases.serviceloader/src/org/osgi/test/cases/serviceloader/junit/ServiceLoaderServiceClientTest.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.AssertionFailedError;
-
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkEvent;
 import org.osgi.framework.FrameworkListener;
@@ -33,6 +31,8 @@ import org.osgi.framework.wiring.BundleRevision;
 import org.osgi.framework.wiring.BundleWire;
 import org.osgi.test.cases.serviceloader.export.TestBridge;
 import org.osgi.test.support.OSGiTestCase;
+
+import junit.framework.AssertionFailedError;
 
 /**
  * TODO Test cases to write:
@@ -213,7 +213,9 @@ public class ServiceLoaderServiceClientTest extends OSGiTestCase {
     				wires = rev.getWiring().getRequiredWires("osgi.serviceloader");
     				assertNotNull(wires);
 
-    				assertEquals("There are two providers so there should be two wires", 2, wires.size());
+					assertTrue(
+							"There should be 2 wires as there are 2 providers, but 1 wire is also allowed since cardinality:=multiple is not guaranteed to provide all wires",
+							(wires.size() == 2) || (wires.size() == 1));
 
     				Collection<ServiceReference<TestBridge>> refs = getContext().getServiceReferences(TestBridge.class, "(test=client)");
     				assertNotNull(refs);


### PR DESCRIPTION
Service Loader test testServiceClientWithFilter which uses
cardinality:=multiple should allow for 1 or 2 wires as
cardinality:=multiple is not required to provide all wires.

This fixes #49