### PR TITLE
Make the Text Extension return the text as a list.

### DIFF
--- a/org.osgi.util.feature/src/org/osgi/util/feature/FeatureExtension.java
+++ b/org.osgi.util.feature/src/org/osgi/util/feature/FeatureExtension.java
@@ -103,10 +103,12 @@ public interface FeatureExtension {
     String getJSON();
 
     /**
-     * Get the Text from this extension.
-     * @return The Text, or {@code null} if this is not a Text extension.
-     */
-    String getText();
+	 * Get the Text from this extension.
+	 * 
+	 * @return The Text line by line, or {@code null} if this is not a Text
+	 *         extension.
+	 */
+	List<String> getText();
 
     /**
      * Get the Artifacts from this extension.

--- a/org.osgi.util.feature/src/org/osgi/util/feature/FeatureExtensionBuilder.java
+++ b/org.osgi.util.feature/src/org/osgi/util/feature/FeatureExtensionBuilder.java
@@ -27,8 +27,8 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface FeatureExtensionBuilder {
 
     /**
-	 * Add text to the extension. Can only be called for extensions of type
-	 * {@link FeatureExtension.Type#TEXT}.
+	 * Add a line of text to the extension. Can only be called for extensions of
+	 * type {@link FeatureExtension.Type#TEXT}.
 	 * 
 	 * @param text The text to be added.
 	 * @return This builder.

--- a/osgi.specs/docbook/708/util.features.xml
+++ b/osgi.specs/docbook/708/util.features.xml
@@ -703,7 +703,6 @@ Feature f = builder.build();</programlisting>
       <para>
         Text extensions support the addition of custom text content to the Feature. 
         The text is provided as a JSON string value or as a JSON array of strings.
-        <remark>update the API to report text as an array</remark>
       </para>
       
       <para>


### PR DESCRIPTION
Addresses the remark from the spec chapter xml.