### PR TITLE
promise: new PromiseFactory.resolvedWith(Promise) method

### DIFF
--- a/org.osgi.test.cases.promise/src/org/osgi/test/cases/promise/junit/PromiseTest.java
+++ b/org.osgi.test.cases.promise/src/org/osgi/test/cases/promise/junit/PromiseTest.java
@@ -1056,6 +1056,90 @@ public class PromiseTest {
 	}
 
 	@Test
+	public void factory_resolved_with_success1() throws Exception {
+		ExecutorService newFixedThreadPool = Executors.newFixedThreadPool(2);
+		try {
+			Integer value = Integer.valueOf(42);
+			final Deferred<Integer> d1 = factory.deferred();
+			final Promise<Integer> p1 = d1.getPromise();
+			PromiseFactory factory2 = new PromiseFactory(newFixedThreadPool,
+					factory.scheduledExecutor(),
+					PromiseFactory.Option.CALLBACKS_EXECUTOR_THREAD);
+			final Promise<Integer> p2 = factory2.resolvedWith(p1);
+			assertThat(p2).doesNotResolveWithin(WAIT_TIME, TimeUnit.SECONDS);
+
+			d1.resolve(value);
+			assertThat(p2).resolvesWithin(WAIT_TIME, TimeUnit.SECONDS)
+					.hasSameValue(value);
+		} finally {
+			newFixedThreadPool.shutdown();
+		}
+	}
+
+	@Test
+	public void factory_resolved_with_success2() throws Exception {
+		ExecutorService newFixedThreadPool = Executors.newFixedThreadPool(2);
+		try {
+			Integer value = Integer.valueOf(42);
+			PromiseFactory factory2 = new PromiseFactory(newFixedThreadPool,
+					factory.scheduledExecutor(),
+					PromiseFactory.Option.CALLBACKS_EXECUTOR_THREAD);
+			final Promise<Integer> p2 = factory2
+					.resolvedWith(factory.resolved(value));
+			assertThat(p2).resolvesWithin(WAIT_TIME, TimeUnit.SECONDS)
+					.hasSameValue(value);
+		} finally {
+			newFixedThreadPool.shutdown();
+		}
+	}
+
+	@Test
+	public void factory_resolved_with_failure1() throws Exception {
+		ExecutorService newFixedThreadPool = Executors.newFixedThreadPool(2);
+		try {
+			Throwable failure = new RuntimeException();
+			final Deferred<Integer> d1 = factory.deferred();
+			final Promise<Integer> p1 = d1.getPromise();
+			PromiseFactory factory2 = new PromiseFactory(newFixedThreadPool,
+					factory.scheduledExecutor(),
+					PromiseFactory.Option.CALLBACKS_EXECUTOR_THREAD);
+			final Promise<Integer> p2 = factory2.resolvedWith(p1);
+			assertThat(p2).doesNotResolveWithin(WAIT_TIME, TimeUnit.SECONDS);
+
+			d1.fail(failure);
+			assertThat(p2).resolvesWithin(WAIT_TIME, TimeUnit.SECONDS)
+					.hasFailedWithThrowableThat()
+					.isSameAs(failure);
+		} finally {
+			newFixedThreadPool.shutdown();
+		}
+	}
+
+	@Test
+	public void factory_resolved_with_failure2() throws Exception {
+		ExecutorService newFixedThreadPool = Executors.newFixedThreadPool(2);
+		try {
+			Throwable failure = new RuntimeException();
+			PromiseFactory factory2 = new PromiseFactory(newFixedThreadPool,
+					factory.scheduledExecutor(),
+					PromiseFactory.Option.CALLBACKS_EXECUTOR_THREAD);
+			final Promise<Integer> p2 = factory2
+					.resolvedWith(factory.failed(failure));
+			assertThat(p2).resolvesWithin(WAIT_TIME, TimeUnit.SECONDS)
+					.hasFailedWithThrowableThat()
+					.isSameAs(failure);
+		} finally {
+			newFixedThreadPool.shutdown();
+		}
+	}
+
+	@Test
+	public void factory_resolved_with_null() throws Exception {
+		assertThatNullPointerException()
+				.isThrownBy(() -> factory.resolvedWith(null));
+	}
+
+	@Test
 	public void testResolveWithNull() throws Exception {
 		Deferred<String> d = factory.deferred();
 		assertThatNullPointerException().isThrownBy(() -> d.resolveWith(null));

--- a/org.osgi.util.promise/src/org/osgi/util/promise/DeferredPromiseImpl.java
+++ b/org.osgi.util.promise/src/org/osgi/util/promise/DeferredPromiseImpl.java
@@ -319,7 +319,7 @@ final class DeferredPromiseImpl<T> extends PromiseImpl<T> {
 	 * 
 	 * @Immutable
 	 */
-	private final class Chain implements Runnable {
+	final class Chain implements Runnable {
 		private final Promise< ? extends T> promise;
 
 		Chain(Promise< ? extends T> promise) {

--- a/org.osgi.util.promise/src/org/osgi/util/promise/PromiseFactory.java
+++ b/org.osgi.util.promise/src/org/osgi/util/promise/PromiseFactory.java
@@ -228,6 +228,40 @@ public class PromiseFactory {
 	}
 
 	/**
+	 * Returns a new Promise that will be resolved with the specified Promise.
+	 * <p>
+	 * The returned Promise uses the callback executor and scheduled executor of
+	 * this PromiseFactory object.
+	 * <p>
+	 * If the specified Promise is successfully resolved, the returned Promise
+	 * is resolved with the value of the specified Promise. If the specified
+	 * Promise is resolved with a failure, the returned Promise is resolved with
+	 * the failure of the specified Promise.
+	 * <p>
+	 * After the returned Promise is resolved with the specified Promise, all
+	 * registered {@link Promise#onResolve(Runnable) callbacks} are called and
+	 * any {@link Promise#then(Success, Failure) chained} Promises are resolved.
+	 * This may occur asynchronously to this method.
+	 * <p>
+	 * Resolving the returned Promise <i>happens-before</i> any registered
+	 * callback is called. That is, in a registered callback,
+	 * {@link Promise#isDone()} must return {@code true} and
+	 * {@link Promise#getValue()} and {@link Promise#getFailure()} must not
+	 * block.
+	 * 
+	 * @param <T> The value type associated with the returned Promise.
+	 * @param with A Promise whose value or failure must be used to resolve the
+	 *            returned Promise. Must not be {@code null}.
+	 * @return A Promise that is resolved with the specified Promise.
+	 * @since 1.2
+	 */
+	public <T> Promise<T> resolvedWith(Promise< ? extends T> with) {
+		DeferredPromiseImpl<T> chained = new DeferredPromiseImpl<>(this);
+		with.onResolve(chained.new Chain(with));
+		return chained.orDone();
+	}
+
+	/**
 	 * Returns a new Promise that has been resolved with the specified failure.
 	 * <p>
 	 * The returned Promise uses the callback executor and scheduled executor of

--- a/osgi.specs/docbook/705/util.promise.xml
+++ b/osgi.specs/docbook/705/util.promise.xml
@@ -16,7 +16,6 @@
    
     SPDX-License-Identifier: Apache-2.0 
  -->
-
 <chapter label="705"
          revision="$Id$"
          version="5.0" xml:id="util.promise"
@@ -670,6 +669,11 @@ Promise&lt;InputStream&gt; in = mirror.then(p -&gt; getStream(p.getValue()));</p
     returning Promises which use the implementation default executors.</para>
 
     <programlisting>  return getTimeConsumingAnswer().fallbackTo(factory.resolved("Fallback Value"));</programlisting>
+
+    <para>The <xref
+    linkend="org.osgi.util.promise.PromiseFactory.resolvedWith-Promise-"
+    xrefstyle="hyperlink"/> method can be used to return a new Promise that
+    will be resolved with the specified promise.</para>
 
     <para>The <xref
     linkend="org.osgi.util.promise.PromiseFactory.submit-Callable-"


### PR DESCRIPTION
This allows the user to create a new Promise using a specific
PromiseFactory that is resolved with the specified promise. If the
user is using multiple promise factories to manage callback thread
usage, this method provides an efficient way to chain a promise
from one promise factory to a new promise from another promise
factory.
