### PR TITLE
[TypedEvent] javadoc - usage topic-level-seperator

### DIFF
--- a/org.osgi.service.typedevent/src/org/osgi/service/typedevent/TypedEventBus.java
+++ b/org.osgi.service.typedevent/src/org/osgi/service/typedevent/TypedEventBus.java
@@ -40,7 +40,7 @@ public interface TypedEventBus {
 	 * type name for the supplied event object.
 	 * <p>
 	 * Logically equivalent to calling
-	 * {@code deliver(event.getClass().getName(), event)}
+	 * {@code deliver(event.getClass().getName().replace('.', '/'), event)}
 	 * 
 	 * @param event The event to send to all listeners which subscribe to the
 	 *            topic of the event.


### PR DESCRIPTION
enhance java-doc as described in spec
```
Topics are arranged in a hierarchical namespace. Each level is defined by a token and levels
are separated by solidi ('/' \u002F).  As a convention, topics should follow the reverse domain 
name scheme used by Java packages to guarantee uniqueness. The separator must be a
solidus ('/' \u002F) instead of the full stop ('.' \u002E). 
```
[link](https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.typedevent.html#typedevent.event.topics)