### PR TITLE
[comp_tck] ConstructorInjection of unavalible optional Reference

### DIFF
--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb27/impl/ConstructorInjection.java
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb27/impl/ConstructorInjection.java
@@ -91,7 +91,9 @@ public class ConstructorInjection implements NamedService {
 
 			Collection<Map<String,Object>> fieldServiceM,
 
-			Collection<ServiceReference<LogService>> fieldServiceReferencesM) {
+			Collection<ServiceReference<LogService>> fieldServiceReferencesM,
+
+			LogService fieldOptionalNull) {
 		/**/
 		System.out.println("constructed");
 		name = configNames.prop();
@@ -103,6 +105,7 @@ public class ConstructorInjection implements NamedService {
 		assertThat(configNames).isNotNull();
 		assertThat(fieldStatic).isNotNull();
 		assertThat(fieldMandatory).isNotNull();
+		assertThat(fieldOptional).isNotNull();
 		assertThat(fieldMultiple).doesNotContainNull();
 		assertThat(fieldAtLeastOne).isNotEmpty().doesNotContainNull();
 		assertThat(fieldGreedy).isNotNull();
@@ -123,6 +126,8 @@ public class ConstructorInjection implements NamedService {
 		assertThat(fieldTupleM).doesNotContainNull();
 		assertThat(fieldServiceM).doesNotContainNull();
 		assertThat(fieldServiceReferencesM).doesNotContainNull();
+		assertThat(fieldOptionalNull).isNull();
+
 	}
 
 	@Override

--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb27/impl/constructorinjection.xml
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb27/impl/constructorinjection.xml
@@ -17,7 +17,7 @@
     SPDX-License-Identifier: Apache-2.0 
  -->
 
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0" name="org.osgi.test.cases.component.tb27.ConstructorInjection" init="25">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0" name="org.osgi.test.cases.component.tb27.ConstructorInjection" init="26">
   <property name="prop" type="String" value="default.prop"/>
   <reference name="atleastone" cardinality="1..n" interface="org.osgi.service.log.LogService" field-collection-type="service" parameter="8"/>
   <reference name="bundle" interface="org.osgi.service.log.LogService" scope="bundle" parameter="13"/>
@@ -30,6 +30,7 @@
   <reference name="mandatory" cardinality="1..1" interface="org.osgi.service.log.LogService" parameter="5"/>
   <reference name="multiple" cardinality="0..n" interface="org.osgi.service.log.LogService" field-collection-type="service" parameter="7"/>
   <reference name="optional" cardinality="0..1" interface="org.osgi.service.log.LogService" parameter="6"/>
+  <reference name="optionalNull" cardinality="0..1" interface="org.osgi.service.log.LogService" target="(no=match)" parameter="25"/>
   <reference name="properties" interface="org.osgi.service.log.LogService" parameter="18"/>
   <reference name="prototype" interface="org.osgi.service.log.LogService" scope="prototype" parameter="14"/>
   <reference name="reference" interface="org.osgi.service.log.LogService" parameter="16"/>


### PR DESCRIPTION
Test the sentence about - [Injection of optional References in Constructor:](https://osgi.github.io/osgi/cmpn/service.component.html#service.component-constructor.injection)
```
If the constructor parameter is associated with a reference having cardinality of 0..1 
and there is no bound service for the reference, then the value null will be supplied as 
the constructor parameter. 
```

Felix fixed this issue in newest versions `2.1.26`

@bjhargrave  would it be okay, to remove the comments and update the version on this position?

https://github.com/osgi/osgi/blob/bf2fd917161748cdaad275d0e90c4d400055d811/cnf/ext/central.mvn#L104-L105

