### PR TITLE
util.converter code contribution from Apache Felix project

### DIFF
--- a/org.osgi.test.cases.converter/src/org/osgi/test/cases/converter/junit/ArrayAndCollectionConversionComplianceTest.java
+++ b/org.osgi.test.cases.converter/src/org/osgi/test/cases/converter/junit/ArrayAndCollectionConversionComplianceTest.java
@@ -18,6 +18,9 @@
 
 package org.osgi.test.cases.converter.junit;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -25,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.jupiter.api.Test;
 import org.osgi.util.converter.ConversionException;
 import org.osgi.util.converter.Converter;
 import org.osgi.util.converter.ConverterBuilder;
@@ -33,13 +37,11 @@ import org.osgi.util.converter.Rule;
 import org.osgi.util.converter.TypeReference;
 import org.osgi.util.function.Function;
 
-import junit.framework.TestCase;
-
 
 /**
  * 707 Converter specification
  */
-public class ArrayAndCollectionConversionComplianceTest extends TestCase {
+public class ArrayAndCollectionConversionComplianceTest {
 
 	/**
 	 * Section 707.4.3 : Arrays and Collections
@@ -56,6 +58,7 @@ public class ArrayAndCollectionConversionComplianceTest extends TestCase {
 	 * Exceptions: Converting a String to a char[] or Character[] will result in
 	 * an array with characters representing the characters in the String.
 	 */
+	@Test
 	public void testConversionFromScalar() {
 		Converter converter = Converters.standardConverter();
 
@@ -94,6 +97,7 @@ public class ArrayAndCollectionConversionComplianceTest extends TestCase {
 	 * <code>String</code> results in a String where each character represents
 	 * the elements of the character array.
 	 */
+	@Test
 	public void testConversionToScalar() {
 		Converter converter = Converters.standardConverter();
 		List<Long> longList = Arrays.asList(5l, 8l, 10l);
@@ -231,6 +235,7 @@ public class ArrayAndCollectionConversionComplianceTest extends TestCase {
 	 * Map.Entry before inserting in the target.</li>
 	 * </ul>
 	 */
+	@Test
 	public void testConversionToArrayOrCollection() {
 		int[] backingObject = new int[] {
 				1, 2, 3
@@ -284,6 +289,7 @@ public class ArrayAndCollectionConversionComplianceTest extends TestCase {
 	 * Conversion to a map-like structure from an Array or Collection is not
 	 * supported by the Standard Converter.
 	 */
+	@Test
 	public void testToMapConversion() {
 		Converter converter = Converters.standardConverter();
 		List<Integer> list = new ArrayList<Integer>();
@@ -293,5 +299,41 @@ public class ArrayAndCollectionConversionComplianceTest extends TestCase {
 			converter.convert(list).to(new TypeReference<Map<String,Integer>>() {});
 			fail("Conversion to a map-like structure from an Array or Collection is not supported by the Standard Converter");
 		} catch (ConversionException e) {}
+	}
+
+	/**
+	 * 707.4.3.1 - null becomes an empty array
+	 */
+	@Test
+	public void testNullToArrayConversion() {
+
+		checkArray(String[].class);
+		checkArray(boolean[].class);
+		checkArray(byte[].class);
+		checkArray(short[].class);
+		checkArray(char[].class);
+		checkArray(int[].class);
+		checkArray(float[].class);
+		checkArray(long[].class);
+		checkArray(double[].class);
+
+		checkArray(String[][][][][].class);
+		checkArray(boolean[][][].class);
+		checkArray(byte[][].class);
+		checkArray(short[][][][].class);
+		checkArray(char[][].class);
+		checkArray(int[][].class);
+		checkArray(float[][][].class);
+		checkArray(long[][][].class);
+		checkArray(double[][].class);
+	}
+
+	private void checkArray(Class< ? > arrayType) {
+		assertTrue(arrayType.isArray());
+
+		Converter converter = Converters.standardConverter();
+		Object array = converter.convert(null).to(arrayType);
+		assertEquals(0, Array.getLength(array));
+		assertTrue(arrayType.isInstance(array));
 	}
 }

--- a/org.osgi.test.cases.converter/src/org/osgi/test/cases/converter/junit/CustomizedConversionComplianceTest.java
+++ b/org.osgi.test.cases.converter/src/org/osgi/test/cases/converter/junit/CustomizedConversionComplianceTest.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package org.osgi.test.cases.converter.junit;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.text.ParseException;
@@ -27,6 +29,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.Test;
 import org.osgi.test.cases.converter.junit.ConversionComplianceTest.ExtObject;
 import org.osgi.test.cases.converter.junit.MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest.MappingBean;
 import org.osgi.util.converter.ConversionException;
@@ -38,10 +41,8 @@ import org.osgi.util.converter.TypeReference;
 import org.osgi.util.converter.TypeRule;
 import org.osgi.util.function.Function;
 
-import junit.framework.TestCase;
 
-
-public class CustomizedConversionComplianceTest extends TestCase {
+public class CustomizedConversionComplianceTest {
 
 	public static class MyBean {
 		private Date	startDate;
@@ -101,6 +102,7 @@ public class CustomizedConversionComplianceTest extends TestCase {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testRepeatedOrDeferredConversion() throws Exception {
 		Converter c = Converters.standardConverter();
 		Function<Object,Integer> cf = c.function().defaultValue(999).to(
@@ -135,6 +137,7 @@ public class CustomizedConversionComplianceTest extends TestCase {
 	 * of a map or other enclosing object
 	 * 
 	 */
+	@Test
 	public void testCustomizedConversion()
 	{
 		final SimpleDateFormat sdf = new SimpleDateFormat("yyMMddHHmmss");
@@ -213,6 +216,7 @@ public class CustomizedConversionComplianceTest extends TestCase {
 	 * that it cannot handle the conversion by returning the CANNOT_HANDLE constant. 
 	 * Rules targeting specific types are evaluated before catch-all rules. 
 	 */
+	@Test
 	public void testCustomizedChainConversion()
 	{
 		final SimpleDateFormat sdf = new SimpleDateFormat("yyMMddHHmmss");
@@ -341,6 +345,7 @@ public class CustomizedConversionComplianceTest extends TestCase {
 	 *   value other than org.osgi.util.converter.ConverterFunction.CANNOT_HANDLE
 	 */
 	// @SuppressWarnings("unchecked")
+	@Test
 	public void testErrorHandler()
 	{
 		final AtomicInteger countError = new AtomicInteger(0);	

--- a/org.osgi.test.cases.converter/src/org/osgi/test/cases/converter/junit/MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest.java
+++ b/org.osgi.test.cases.converter/src/org/osgi/test/cases/converter/junit/MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest.java
@@ -19,9 +19,11 @@
 package org.osgi.test.cases.converter.junit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
@@ -44,6 +46,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeMap;
 
+import org.junit.jupiter.api.Test;
 import org.osgi.dto.DTO;
 import org.osgi.test.cases.converter.junit.ConversionComplianceTest.ExtObject;
 import org.osgi.util.converter.ConversionException;
@@ -52,14 +55,11 @@ import org.osgi.util.converter.ConverterFunction;
 import org.osgi.util.converter.Converters;
 import org.osgi.util.converter.TypeReference;
 
-import junit.framework.TestCase;
-
 
 /**
  * 707 Converter specification
  */
-public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
-		extends TestCase {
+public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest {
 
 	@Retention(RetentionPolicy.RUNTIME)
 	public static @interface AnnotationInterface {
@@ -478,6 +478,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 	 * Conversions from a scalar to a map-like type are not supported by the
 	 * standard converter.
 	 */
+	@Test
 	public void testFromScalarConversion() {
 		Converter converter = Converters.standardConverter();
 		try {
@@ -498,6 +499,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 	 * <p/>
 	 * An empty map results in a null scalar value.
 	 */
+	@Test
 	public void testToScalarConversion() {
 		Converter converter = Converters.standardConverter();
 		
@@ -527,6 +529,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 	 * called Arrays and Collections and the section called Map.Entry.
 	 * @throws ParseException 
 	 */
+	@Test
 	public void testToArrayOrCollectionConversion() throws ParseException {
 				
 		TimeZone tz = TimeZone.getTimeZone("UTC");			
@@ -608,6 +611,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 	 * available, key-value pairs are used in the map as-is
 	 */
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testMapConversion() {
 		Converter converter = Converters.standardConverter();
 		DTOLike dtolike = new DTOLike();
@@ -674,6 +678,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 	 * target type information for Dictionaries can be provided via a
 	 * TypeReference.
 	 */
+	@Test
 	public void testDictionaryConversion() {
 		Converter converter = Converters.standardConverter();
 		DTOLike dtolike = new DTOLike();
@@ -759,6 +764,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 	 * using the sourceAs(Class) modifier.
 	 */
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testInterfaceConversion() {
 
 		DTOLike dtolike = new DTOLike();
@@ -847,6 +853,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 	 * Similar to interfaces, conversions to and from annotations also follow
 	 * the Key Mapping section for annotation element names.
 	 */
+	@Test
 	public void testAnnotationConversion() {
 
 		DTOLike dtolike = new DTOLike();
@@ -928,6 +935,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 	 * Note: the getClass() method of the java.lang.Object class is not
 	 * considered an accessor.
 	 */
+	@Test
 	public void testJavaBeanConversion() {
 
 		ConversionComplianceTest.ExtObject embedded = new ConversionComplianceTest.ExtObject();
@@ -1003,6 +1011,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 	 * methods, the converter can be instructed to do this using the
 	 * sourceAsDTO() and targetAsDTO() modifiers.
 	 */
+	@Test
 	public void testDTOConversion() {
 		Converter converter = Converters.standardConverter();
 
@@ -1071,6 +1080,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 	 * Note: this mechanism can only be used to convert to another type. The
 	 * reverse is not supported
 	 */
+	@Test
 	public void testTypesWithGetPropertiesConversion() {
 
 		Converter converter = Converters.standardConverter();
@@ -1152,6 +1162,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 	 * prefixed with the value of the <code>PREFIX_</code> field.</li>
 	 * </ul>
 	 */
+	@Test
 	public void testKeyMapping() {
 
 		Map<String,String> resultmap = new HashMap<String,String>();
@@ -1360,6 +1371,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 		assertEquals(inter.special$$_$prop(), resultinter.special$$_$prop());
 	}
 
+	@Test
 	public void testMapToDTOWithGenerics() {
 		Map<String,Object> dto = new HashMap<>();
 
@@ -1410,6 +1422,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 		}
 	}
 
+	@Test
 	public void testMapToDTOWithGenericVariables() {
 		Map<String,Object> dto = new HashMap<>();
 		dto.put("set", new HashSet<>(Arrays.asList("foo", (int) 'o', 'o')));
@@ -1427,6 +1440,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 				converted.set);
 	}
 
+	@Test
 	public void testMapToInterfaceWithGenerics() {
 		Map<String,Object> dto = new HashMap<>();
 		dto.put("charSet", new HashSet<>(Arrays.asList("foo", (int) 'o', 'o')));
@@ -1438,6 +1452,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 				converted.charSet());
 	}
 
+	@Test
 	public void testMapToInterfaceWithErrorHandler() {
 		Map<String,Object> dto = new HashMap<>();
 		final Object BAD = new Object();
@@ -1469,6 +1484,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 				'o');
 	}
 
+	@Test
 	public void testMapToInterfaceWithGenericVariables() {
 		Map<String,Object> dto = new HashMap<>();
 		dto.put("set", new HashSet<>(Arrays.asList("foo", (int) 'o', 'o')));
@@ -1487,6 +1503,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 				converted.set());
 	}
 
+	@Test
 	public void testConvertMarkerAnnotation() {
 		Converter converter = Converters.standardConverter();
 
@@ -1521,6 +1538,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 		assertEquals("true", m2.get("my.marker.annotation"));
 	}
 
+	@Test
 	public void testConvertSingleElementAnnotation() {
 		Converter converter = Converters.standardConverter();
 
@@ -1550,6 +1568,7 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 		assertEquals(Long.valueOf(456L), m3.get("single.element.annotation"));
 	}
 
+	@Test
 	public void testSingleElementAnnotationPrefix() {
 		Map<String,String> m = new HashMap<>();
 		m.put("org.foo.bar.single.element.annotation.prefix", "-999");
@@ -1559,5 +1578,75 @@ public class MapInterfaceJavaBeansDTOAndAnnotationConversionComplianceTest
 		SingleElementAnnotationPrefix ann = converter.convert(m)
 				.to(SingleElementAnnotationPrefix.class);
 		assertEquals(-999L, ann.value());
+	}
+
+	static interface EmptyInterface {
+	}
+
+	static interface EmptyInterface2 extends EmptyInterface {
+	}
+
+	static interface NonEmptyInterface {
+		int a();
+	}
+
+	static interface EmptyInterface3 extends NonEmptyInterface {
+	}
+
+	@Test
+	public void testMapToEmptyInterface() throws Exception {
+		Map<String,Object> map = new HashMap<String,Object>();
+		map.put("a", "b");
+		EmptyInterface i = Converters.standardConverter()
+				.convert(map)
+				.to(EmptyInterface.class);
+		assertThat(i).isInstanceOf(EmptyInterface.class);
+
+		EmptyInterface2 j = Converters.standardConverter()
+				.convert(map)
+				.to(EmptyInterface2.class);
+		assertThat(j).isInstanceOf(EmptyInterface2.class);
+
+		EmptyInterface3 k = Converters.standardConverter()
+				.convert(map)
+				.to(EmptyInterface3.class);
+		assertThat(k).isInstanceOf(EmptyInterface3.class);
+	}
+
+	public static interface InterfaceWithDefaultMethod {
+		public static final String RESULT = "r";
+
+		public default String defaultMethod() {
+			return RESULT;
+		}
+	}
+
+	@Test
+	public void testDefaultInterfaceMethod() throws Throwable {
+		Class< ? > clazz = InterfaceWithDefaultMethod.class;
+		InterfaceWithDefaultMethod i = (InterfaceWithDefaultMethod) Converters
+				.standardConverter()
+				.convert(new HashMap<String,Object>())
+				.to(clazz);
+		assertEquals(InterfaceWithDefaultMethod.RESULT, i.defaultMethod());
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface PrefixMarkerAnnotation {
+		static final String PREFIX_ = "org.foo.bar.";
+	}
+
+	@Test
+	@PrefixMarkerAnnotation
+	public void testMarkerAnnotationPrefixToMap() throws Exception {
+		final Converter converter = Converters.standardConverter();
+		Method method = getClass().getMethod("testMarkerAnnotationPrefixToMap");
+		PrefixMarkerAnnotation annotation = method
+				.getDeclaredAnnotation(PrefixMarkerAnnotation.class);
+		Map<String,Object> map = converter.convert(annotation)
+				.to(new TypeReference<Map<String,Object>>() {
+				});
+		assertTrue(map.containsKey("org.foo.bar.prefix.marker.annotation"));
+		assertTrue((Boolean) map.get("org.foo.bar.prefix.marker.annotation"));
 	}
 }

--- a/org.osgi.test.cases.converter/src/org/osgi/test/cases/converter/junit/ScalarConversionComplianceTest.java
+++ b/org.osgi.test.cases.converter/src/org/osgi/test/cases/converter/junit/ScalarConversionComplianceTest.java
@@ -18,19 +18,19 @@
 
 package org.osgi.test.cases.converter.junit;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-//import java.time.Duration;
-//import java.time.Instant;
-//import java.time.LocalDate;
-//import java.time.LocalDateTime;
-//import java.time.LocalTime;
-//import java.time.MonthDay;
-//import java.time.OffsetDateTime;
-//import java.time.OffsetTime;
-//import java.time.Year;
-//import java.time.YearMonth;
-//import java.time.ZonedDateTime;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetTime;
+import java.time.Year;
+import java.time.YearMonth;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -40,18 +40,17 @@ import java.util.TimeZone;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import org.junit.jupiter.api.Test;
 import org.osgi.util.converter.ConversionException;
 import org.osgi.util.converter.Converter;
 import org.osgi.util.converter.Converters;
 import org.osgi.util.converter.TypeReference;
 
-import junit.framework.TestCase;
-
 
 /**
  * 707 Converter specification
  */
-public class ScalarConversionComplianceTest extends TestCase {
+public class ScalarConversionComplianceTest {
 
 	/**
 	 * Section 707.4.2 - Scalars
@@ -79,6 +78,7 @@ public class ScalarConversionComplianceTest extends TestCase {
 	 * </tr>
 	 * </table>
 	 */
+	@Test
 	public void testScalarConversionFromBoolean() {
 		Converter converter = Converters.standardConverter();
 
@@ -133,6 +133,7 @@ public class ScalarConversionComplianceTest extends TestCase {
 	 * </tr>
 	 * </table>
 	 */
+	@Test
 	public void testScalarConversionFromCharacter() {
 		Converter converter = Converters.standardConverter();
 
@@ -187,6 +188,7 @@ public class ScalarConversionComplianceTest extends TestCase {
 	 * </tr>
 	 * </table>
 	 */
+	@Test
 	public void testScalarConversionFromNumber() {
 		Converter converter = Converters.standardConverter();
 
@@ -241,6 +243,7 @@ public class ScalarConversionComplianceTest extends TestCase {
 	 * </tr>
 	 * </table>
 	 */
+	@Test
 	public void testScalarConversionFromNull() {
 		Converter converter = Converters.standardConverter();
 
@@ -265,6 +268,7 @@ public class ScalarConversionComplianceTest extends TestCase {
 	 * <p/>
 	 * A null object results in a null String value
 	 */
+	@Test
 	public void testScalarConversionToString() {
 
 		boolean fstToBeConverted = true;
@@ -298,6 +302,7 @@ public class ScalarConversionComplianceTest extends TestCase {
 	 * 2. public constructor taking a single String argument
 	 * <p/>
 	 */
+	@Test
 	public void testScalarConversionFromString() {
 		String fstToBeConverted = "myObject";
 		String sndToBeConverted = "9";
@@ -394,6 +399,7 @@ public class ScalarConversionComplianceTest extends TestCase {
 	 * </tr>
 	 * </table>
 	 */
+	@Test
 	public void testScalarConversionFromStringSpecial() {
 		Converter converter = Converters.standardConverter();
 
@@ -406,56 +412,58 @@ public class ScalarConversionComplianceTest extends TestCase {
 		assertEquals('A', c);
 
 		// java 1.8 data structures
-//		String duration = "PT10H";
-//		Duration d = converter.convert(duration).to(Duration.class);
-//		assertEquals(Duration.parse("PT10H"), d);
-//
-//		String instant = "2013-05-30T23:38:23.085Z";
-//		Instant i = converter.convert(instant).to(Instant.class);
-//		assertEquals(Instant.parse("2013-05-30T23:38:23.085Z"), i);
-//
-//		String localDateStr = "2013-11-24";
-//		LocalDate localDate = LocalDate.parse(localDateStr);
-//		LocalDate localDateConverted = converter.convert(localDateStr)
-//				.to(LocalDate.class);
-//		assertEquals(0, localDate.compareTo(localDateConverted));
-//
-//		String localDateTimeStr = "2013-11-24T07:21:00";
-//		LocalDateTime localDateTime = converter.convert(localDateTimeStr)
-//				.to(LocalDateTime.class);
-//		assertEquals(LocalDateTime.parse(localDateTimeStr), localDateTime);
-//
-//		String localTimeStr = "07:21:00";
-//		LocalTime localTime = converter.convert(localTimeStr)
-//				.to(LocalTime.class);
-//		assertEquals(LocalTime.parse(localTimeStr), localTime);
-//
-//		String monthDay = "--11-24";
-//		MonthDay md = converter.convert(monthDay).to(MonthDay.class);
-//		assertEquals(MonthDay.parse(monthDay), md);
-//
-//		String offsetTimeStr = "07:21:00+01:00";
-//		OffsetTime offsetTime = converter.convert(offsetTimeStr)
-//				.to(OffsetTime.class);
-//		assertEquals(OffsetTime.parse(offsetTimeStr), offsetTime);
-//
-//		String offsetDateTimeStr = "2007-12-03T10:15:30+01:00";
-//		OffsetDateTime offsetDateTime = converter.convert(offsetDateTimeStr)
-//				.to(OffsetDateTime.class);
-//		assertEquals(OffsetDateTime.parse(offsetTimeStr), offsetDateTime);
-//
-//		String year = "2017";
-//		Year y = converter.convert(year).to(Year.class);
-//		assertEquals(Year.parse(year), y);
-//
-//		String yearMonth = "2017-11";
-//		YearMonth ym = converter.convert(yearMonth).to(YearMonth.class);
-//		assertEquals(YearMonth.parse(yearMonth), y);
-//
-//		String zonedDateTimeStr = "2013-11-24T07:21:00+01:00 Europe/Paris";
-//		ZonedDateTime zonedDateTime = converter.convert(zonedDateTimeStr)
-//				.to(ZonedDateTime.class);
-//		assertEquals(ZonedDateTime.parse(zonedDateTimeStr), zonedDateTime);
+		String duration = "PT10H";
+		Duration d = converter.convert(duration).to(Duration.class);
+		assertEquals(Duration.parse("PT10H"), d);
+
+		String instant = "2013-05-30T23:38:23.085Z";
+		Instant i = converter.convert(instant).to(Instant.class);
+		assertEquals(Instant.parse("2013-05-30T23:38:23.085Z"), i);
+
+		String localDateStr = "2013-11-24";
+		LocalDate localDate = LocalDate.parse(localDateStr);
+		LocalDate localDateConverted = converter.convert(localDateStr)
+				.to(LocalDate.class);
+		assertEquals(0, localDate.compareTo(localDateConverted));
+
+		String localDateTimeStr = "2013-11-24T07:21:00";
+		LocalDateTime localDateTime = converter.convert(localDateTimeStr)
+				.to(LocalDateTime.class);
+		assertEquals(LocalDateTime.parse(localDateTimeStr), localDateTime);
+
+		String localTimeStr = "07:21:00";
+		LocalTime localTime = converter.convert(localTimeStr)
+				.to(LocalTime.class);
+		assertEquals(LocalTime.parse(localTimeStr), localTime);
+
+		String monthDay = "--11-24";
+		MonthDay md = converter.convert(monthDay).to(MonthDay.class);
+		assertEquals(MonthDay.parse(monthDay), md);
+
+		String offsetTimeStr = "07:21:00+01:00";
+		OffsetTime offsetTime = converter.convert(offsetTimeStr)
+				.to(OffsetTime.class);
+		assertEquals(OffsetTime.parse(offsetTimeStr), offsetTime);
+
+		// TODO fixme
+		// String offsetDateTimeStr = "2007-12-03T10:15:30+01:00";
+		// OffsetDateTime offsetDateTime = converter.convert(offsetDateTimeStr)
+		// .to(OffsetDateTime.class);
+		// assertEquals(OffsetDateTime.parse(offsetTimeStr), offsetDateTime);
+
+		String year = "2017";
+		Year y = converter.convert(year).to(Year.class);
+		assertEquals(Year.parse(year), y);
+
+		String yearMonth = "2017-11";
+		YearMonth ym = converter.convert(yearMonth).to(YearMonth.class);
+		assertEquals(YearMonth.parse(yearMonth), ym);
+
+		// TODO fixme
+		// String zonedDateTimeStr = "2013-11-24T07:21:00+01:00 Europe/Paris";
+		// ZonedDateTime zonedDateTime = converter.convert(zonedDateTimeStr)
+		// .to(ZonedDateTime.class);
+		// assertEquals(ZonedDateTime.parse(zonedDateTimeStr), zonedDateTime);
 
 		String uuidStr = "0-0-0-0-FF";
 		UUID convertedUUID = converter.convert(uuidStr).to(UUID.class);
@@ -488,6 +496,7 @@ public class ScalarConversionComplianceTest extends TestCase {
 	 * setting the time in the Calendar object via setTime().
 	 * <p/>
 	 */
+	@Test
 	public void testScalarConversionDateAndCalendar() {
 		Converter converter = Converters.standardConverter();
 		TimeZone tz = TimeZone.getTimeZone("UTC");
@@ -549,6 +558,7 @@ public class ScalarConversionComplianceTest extends TestCase {
 	 * Primitives are boxed before conversion is done. Other source types are
 	 * converted to String before converting to Enum.
 	 */
+	@Test
 	public void testScalarConversionEnum() {
 		Converter converter = Converters.standardConverter();
 		Number fstToBeConverted = 4l;
@@ -601,6 +611,7 @@ public class ScalarConversionComplianceTest extends TestCase {
 	 * <p/>
 	 * Conversion to Map.Entry from a scalar is not supported.
 	 */
+	@Test
 	public void testScalarConversionMapEntryKeyOrValueSameType() {
 		Converter converter = Converters.standardConverter();
 
@@ -694,5 +705,22 @@ public class ScalarConversionComplianceTest extends TestCase {
 					.to(new TypeReference<Map.Entry<String,String>>() {});
 			fail("ConversionException expected");
 		} catch (ConversionException e) {}
+	}
+
+	@Test
+	public void testConvertBooleanToNumber() {
+		Converter converter = Converters.standardConverter();
+		assertEquals(Byte.valueOf((byte) 1),
+				converter.convert(Boolean.TRUE).to(Byte.class));
+		assertEquals(Short.valueOf((short) 1),
+				converter.convert(Boolean.TRUE).to(Short.class));
+		assertEquals(Integer.valueOf(1),
+				converter.convert(Boolean.TRUE).to(Integer.class));
+		assertEquals(Long.valueOf(1),
+				converter.convert(Boolean.TRUE).to(Long.class));
+		assertEquals(Float.valueOf(1.0f),
+				converter.convert(Boolean.TRUE).to(Float.class));
+		assertEquals(Double.valueOf(1.0d),
+				converter.convert(Boolean.TRUE).to(Double.class));
 	}
 }

--- a/org.osgi.test.cases.converter/src/org/osgi/test/cases/converter/junit/StandardConverterComplianceTest.java
+++ b/org.osgi.test.cases.converter/src/org/osgi/test/cases/converter/junit/StandardConverterComplianceTest.java
@@ -18,6 +18,7 @@
 package org.osgi.test.cases.converter.junit;
 
 import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -29,17 +30,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
 import org.osgi.dto.DTO;
 import org.osgi.util.converter.Converter;
 import org.osgi.util.converter.Converters;
 import org.osgi.util.converter.TypeReference;
 
-import junit.framework.TestCase;
-
 /**
  * 
  */
-public class StandardConverterComplianceTest extends TestCase{
+public class StandardConverterComplianceTest {
 
 	/**
 	 * Section 707.4 : Conversions
@@ -54,6 +54,7 @@ public class StandardConverterComplianceTest extends TestCase{
 	 * type. This copy can be owned and optionally further modified by the
 	 * caller.
 	 */
+	@Test
 	public void testUnecessaryConversion()
 	{
 		BigDecimal bd = new BigDecimal(5);
@@ -96,6 +97,7 @@ public class StandardConverterComplianceTest extends TestCase{
 	 * c.convert("123").to(new TypeReference<List<Long>>()); // list will
 	 * contain the Long value 123L
 	 */
+	@Test
 	public void testGenericConversion() {
 		Converter converter = Converters.standardConverter();
 		List<String> list = converter.convert(Arrays.<Integer> asList(1, 2, 3))
@@ -113,6 +115,7 @@ public class StandardConverterComplianceTest extends TestCase{
 	 * When converting to a target type with generic fields the converter should
 	 * convert the nested data as necessary
 	 */
+	@Test
 	public void testGenericFieldConversion() {
 		Converter converter = Converters.standardConverter();
 		GenericFieldDto dto = converter
@@ -136,6 +139,7 @@ public class StandardConverterComplianceTest extends TestCase{
 	 * When converting to a target type with parameterized fields the converter
 	 * should convert the nested data as defined by the {@link TypeReference}
 	 */
+	@Test
 	public void testParameterizedGenericFieldConversion() {
 		Converter converter = Converters.standardConverter();
 		ParameterizedFieldDto<String> dto = converter
@@ -167,6 +171,7 @@ public class StandardConverterComplianceTest extends TestCase{
 	 * When converting to a target type which reifies parameterized fields the
 	 * converter should convert the nested data as defined by the type variables
 	 */
+	@Test
 	public void testReifiedGenericFieldConversion() {
 		Converter converter = Converters.standardConverter();
 		ReifiedFieldDto dto = converter
@@ -187,6 +192,7 @@ public class StandardConverterComplianceTest extends TestCase{
 	 * converter should convert the nested data as defined by the type variables
 	 * This test looks at a subclass that indirectly binds a type variable
 	 */
+	@Test
 	public void testReifiedGenericFieldConversionSubclass() {
 		Converter converter = Converters.standardConverter();
 		ReifiedFieldDtoSub dto = converter
@@ -211,6 +217,7 @@ public class StandardConverterComplianceTest extends TestCase{
 	 * converter should convert the nested data as defined by the type variables
 	 * This test looks at a subclass that indirectly binds a type variable
 	 */
+	@Test
 	public void testWildcardGenerics() {
 
 		HashSet<Character> charSet = new HashSet<>(

--- a/org.osgi.util.converter/src/org/osgi/util/converter/ConverterImpl.java
+++ b/org.osgi.util.converter/src/org/osgi/util/converter/ConverterImpl.java
@@ -288,6 +288,11 @@ class ConverterImpl implements InternalConverter {
 		reflectiveAddJavaTimeRule(cb, "java.time.OffsetDateTime");
 		reflectiveAddJavaTimeRule(cb, "java.time.OffsetTime");
 		reflectiveAddJavaTimeRule(cb, "java.time.ZonedDateTime");
+		reflectiveAddJavaTimeRule(cb, "java.time.Instant");
+		reflectiveAddJavaTimeRule(cb, "java.time.Duration");
+		reflectiveAddJavaTimeRule(cb, "java.time.Year");
+		reflectiveAddJavaTimeRule(cb, "java.time.YearMonth");
+		reflectiveAddJavaTimeRule(cb, "java.time.MonthDay");
 	}
 
 	private void reflectiveAddJavaTimeRule(ConverterBuilder cb,

--- a/org.osgi.util.converter/src/org/osgi/util/converter/Converting.java
+++ b/org.osgi.util.converter/src/org/osgi/util/converter/Converting.java
@@ -35,6 +35,7 @@ public interface Converting extends Specifying<Converting> {
 	 * Specify the target object type for the conversion as a class object.
 	 *
 	 * @param cls The class to convert to.
+	 * @param <T> The type to convert to.
 	 * @return The converted object.
 	 */
 	<T> T to(Class<T> cls);
@@ -44,6 +45,7 @@ public interface Converting extends Specifying<Converting> {
 	 *
 	 * @param type A Type object to represent the target type to be converted
 	 *            to.
+	 * @param <T> The type to convert to.
 	 * @return The converted object.
 	 */
 	<T> T to(Type type);
@@ -56,10 +58,12 @@ public interface Converting extends Specifying<Converting> {
 	 *
 	 * <pre>
 	 * List&lt;String&gt; result = converter.convert(Arrays.asList(1, 2, 3))
-	 * 		.to(new TypeReference&lt;List&lt;String&gt;&gt;() {});
+	 * 		.to(new TypeReference&lt;List&lt;String&gt;&gt;() {
+	 * 		});
 	 * </pre>
 	 *
 	 * @param ref A type reference to the object being converted to.
+	 * @param <T> The type to convert to.
 	 * @return The converted object.
 	 */
 	<T> T to(TypeReference<T> ref);

--- a/org.osgi.util.converter/src/org/osgi/util/converter/Functioning.java
+++ b/org.osgi.util.converter/src/org/osgi/util/converter/Functioning.java
@@ -37,6 +37,7 @@ public interface Functioning extends Specifying<Functioning> {
 	 * Specify the target object type for the conversion as a class object.
 	 *
 	 * @param cls The class to convert to.
+	 * @param <T> The type to convert to.
 	 * @return A function that can perform the conversion.
 	 */
 	<T> Function<Object,T> to(Class<T> cls);
@@ -46,6 +47,7 @@ public interface Functioning extends Specifying<Functioning> {
 	 *
 	 * @param type A Type object to represent the target type to be converted
 	 *            to.
+	 * @param <T> The type to convert to.
 	 * @return A function that can perform the conversion.
 	 */
 	<T> Function<Object,T> to(Type type);
@@ -58,10 +60,12 @@ public interface Functioning extends Specifying<Functioning> {
 	 *
 	 * <pre>
 	 * List&lt;String&gt; result = converter.function()
-	 * 		.to(new TypeReference&lt;List&lt;String&gt;&gt;() {});
+	 * 		.to(new TypeReference&lt;List&lt;String&gt;&gt;() {
+	 * 		});
 	 * </pre>
 	 *
 	 * @param ref A type reference to the object being converted to.
+	 * @param <T> The type to convert to.
 	 * @return A function that can perform the conversion.
 	 */
 	<T> Function<Object,T> to(TypeReference<T> ref);

--- a/org.osgi.util.converter/src/org/osgi/util/converter/FunctioningImpl.java
+++ b/org.osgi.util.converter/src/org/osgi/util/converter/FunctioningImpl.java
@@ -27,10 +27,10 @@ import org.osgi.util.function.Function;
  */
 class FunctioningImpl extends AbstractSpecifying<Functioning>
 		implements Functioning {
-	InternalConverter converter;
+	InternalConverter initialConverter;
 
-	FunctioningImpl(InternalConverter converterImpl) {
-		converter = converterImpl;
+	FunctioningImpl(InternalConverter converter) {
+		initialConverter = converter;
 	}
 
 	@Override
@@ -49,32 +49,32 @@ class FunctioningImpl extends AbstractSpecifying<Functioning>
 		return new Function<Object,T>() {
 			@Override
 			public T apply(Object t) {
-				InternalConverting ic = converter.convert(t);
-				return applyModifiers(ic).to(type);
+				InternalConverting converter = initialConverter.convert(t);
+				return applyModifiers(converter).to(type);
 			}
 		};
 	}
 
-	InternalConverting applyModifiers(InternalConverting ic) {
+	InternalConverting applyModifiers(InternalConverting converter) {
 		if (hasDefault)
-			ic.defaultValue(defaultValue);
+			converter.defaultValue(defaultValue);
 		if (liveView)
-			ic.view();
+			converter.view();
 		if (keysIgnoreCase)
-			ic.keysIgnoreCase();
+			converter.keysIgnoreCase();
 		if (sourceAsClass != null)
-			ic.sourceAs(sourceAsClass);
+			converter.sourceAs(sourceAsClass);
 		if (sourceAsDTO)
-			ic.sourceAsDTO();
+			converter.sourceAsDTO();
 		if (sourceAsJavaBean)
-			ic.sourceAsBean();
+			converter.sourceAsBean();
 		if (targetAsClass != null)
-			ic.targetAs(targetAsClass);
+			converter.targetAs(targetAsClass);
 		if (targetAsDTO)
-			ic.targetAsBean();
+			converter.targetAsBean();
 		if (targetAsJavaBean)
-			ic.targetAsBean();
+			converter.targetAsBean();
 
-		return ic;
+		return converter;
 	}
 }

--- a/org.osgi.util.converter/src/org/osgi/util/converter/InternalConverting.java
+++ b/org.osgi.util.converter/src/org/osgi/util/converter/InternalConverting.java
@@ -18,19 +18,28 @@
 
 package org.osgi.util.converter;
 
+import java.lang.reflect.Type;
+
 /**
  * This interface is the same as the {@link Converting} interface with the
  * addition that the current converter (which may include custom rules) can be
  * set on it. This allows the converter to be re-entrant and use itself for
  * sub-conversions if applicable.
- * 
+ *
  * @author $Id$
  */
 interface InternalConverting extends Converting {
 	/**
-	 * Set the current converter.
-	 * 
-	 * @param c The current converter.
+	 * Invoke the conversion while passing the top-level converter. The
+	 * top-level converter is needed when performing embedded conversions such
+	 * as in map elements. When using a custom converter, the top converter must
+	 * be used for this.
+	 *
+	 * @param type A Type object to represent the target type to be converted
+	 *            to.
+	 * @param <T> The type to convert to.
+	 * @param converter Internal converter
+	 * @return The converted object.
 	 */
-	void setConverter(Converter c);
+	<T> T to(Type type, InternalConverter converter);
 }

--- a/org.osgi.util.converter/src/org/osgi/util/converter/ListDelegate.java
+++ b/org.osgi.util.converter/src/org/osgi/util/converter/ListDelegate.java
@@ -34,26 +34,30 @@ class ListDelegate<T> implements List<T> {
 	private volatile List<T>		delegate;
 	private volatile boolean		cloned;
 	private final ConvertingImpl	convertingImpl;
+	private final InternalConverter	converter;
 
 	@SuppressWarnings({
 			"unchecked", "rawtypes"
 	})
-	static <T> List<T> forArray(Object arr, ConvertingImpl converting) {
-		return new ListDelegate<T>(new ArrayDelegate(arr), converting);
+	static <T> List<T> forArray(Object arr, ConvertingImpl converting,
+			InternalConverter c) {
+		return new ListDelegate<T>(new ArrayDelegate(arr), converting, c);
 	}
 
 	static <T> List<T> forCollection(Collection<T> object,
-			ConvertingImpl converting) {
+			ConvertingImpl converting, InternalConverter c) {
 		if (object instanceof List) {
-			return new ListDelegate<T>((List<T>) object, converting);
+			return new ListDelegate<T>((List<T>) object, converting, c);
 		}
-		return new ListDelegate<T>(new CollectionDelegate<>(object),
-				converting);
+		return new ListDelegate<T>(new CollectionDelegate<>(object), converting,
+				c);
 	}
 
-	private ListDelegate(List<T> del, ConvertingImpl conv) {
+	private ListDelegate(List<T> del, ConvertingImpl conv,
+			InternalConverter c) {
 		delegate = del;
 		convertingImpl = conv;
+		converter = c;
 	}
 
 	// Whenever a modification is made, the delegate is cloned and detached.
@@ -173,7 +177,8 @@ class ListDelegate<T> implements List<T> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public T get(int index) {
-		return (T) convertingImpl.convertCollectionValue(delegate.get(index));
+		return (T) convertingImpl.convertCollectionValue(delegate.get(index),
+				converter);
 	}
 
 	@Override

--- a/org.osgi.util.converter/src/org/osgi/util/converter/MapDelegate.java
+++ b/org.osgi.util.converter/src/org/osgi/util/converter/MapDelegate.java
@@ -35,39 +35,43 @@ class MapDelegate<K, V> implements Map<K,V> {
 	// once, which is harmless.
 	private volatile boolean		cloned	= false;
 	private final ConvertingImpl	convertingImpl;
+	private final InternalConverter	converter;
 	Map<K,V>						delegate;
 
-	private MapDelegate(ConvertingImpl converting, Map<K,V> del) {
+	private MapDelegate(ConvertingImpl converting, InternalConverter c,
+			Map<K,V> del) {
 		convertingImpl = converting;
+		converter = c;
 		delegate = del;
 	}
 
 	static MapDelegate<String,Object> forBean(Object b, Class< ? > beanClass,
-			ConvertingImpl converting) {
-		return new MapDelegate<>(converting,
+			ConvertingImpl converting, InternalConverter c) {
+		return new MapDelegate<>(converting, c,
 				new DynamicBeanFacade(b, beanClass, converting));
 	}
 
-	static <K, V> Map<K,V> forMap(Map<K,V> m, ConvertingImpl converting) {
-		return new MapDelegate<>(converting,
+	static <K, V> Map<K,V> forMap(Map<K,V> m, ConvertingImpl converting,
+			InternalConverter c) {
+		return new MapDelegate<>(converting, c,
 				new DynamicMapFacade<>(m, converting));
 	}
 
 	static <K, V> MapDelegate<K,V> forDictionary(Dictionary<K,V> d,
-			ConvertingImpl converting) {
-		return new MapDelegate<>(converting,
+			ConvertingImpl converting, InternalConverter c) {
+		return new MapDelegate<>(converting, c,
 				new DynamicDictionaryFacade<>(d, converting));
 	}
 
 	static MapDelegate<String,Object> forDTO(Object obj, Class< ? > dtoClass,
-			ConvertingImpl converting) {
-		return new MapDelegate<>(converting,
+			ConvertingImpl converting, InternalConverter c) {
+		return new MapDelegate<>(converting, c,
 				new DynamicDTOFacade(obj, dtoClass, converting));
 	}
 
 	static MapDelegate<String,Object> forInterface(Object obj, Class< ? > intf,
-			ConvertingImpl converting) {
-		return new MapDelegate<>(converting,
+			ConvertingImpl converting, InternalConverter c) {
+		return new MapDelegate<>(converting, c,
 				new DynamicInterfaceFacade(obj, intf, converting));
 	}
 
@@ -119,11 +123,11 @@ class MapDelegate<K, V> implements Map<K,V> {
 	}
 
 	private Object getConvertedKey(Object key) {
-		return convertingImpl.convertMapKey(key);
+		return convertingImpl.convertMapKey(key, converter);
 	}
 
 	private Object getConvertedValue(Object val) {
-		return convertingImpl.convertMapValue(val);
+		return convertingImpl.convertMapValue(val, converter);
 	}
 
 	private Object findConvertedKey(Set< ? > keySet, Object key) {
@@ -133,7 +137,7 @@ class MapDelegate<K, V> implements Map<K,V> {
 		}
 
 		for (Object k : keySet) {
-			Object c = convertingImpl.converter.convert(k).to(key.getClass());
+			Object c = converter.convert(k).to(key.getClass());
 			if (c != null && c.equals(key))
 				return k;
 		}

--- a/org.osgi.util.converter/src/org/osgi/util/converter/SetDelegate.java
+++ b/org.osgi.util.converter/src/org/osgi/util/converter/SetDelegate.java
@@ -34,19 +34,22 @@ class SetDelegate<T> implements Set<T> {
 	private volatile Set<T>			delegate;
 	private volatile boolean		cloned;
 	private final ConvertingImpl	convertingImpl;
+	private final InternalConverter	converter;
 
 	static <T> Set<T> forCollection(Collection<T> collection,
-			ConvertingImpl converting) {
+			ConvertingImpl converting, InternalConverter c) {
 		if (collection instanceof Set) {
-			return new SetDelegate<T>((Set<T>) collection, converting);
+			return new SetDelegate<T>((Set<T>) collection, converting, c);
 		}
 		return new SetDelegate<T>(new CollectionSetDelegate<>(collection),
-				converting);
+				converting, c);
 	}
 
-	SetDelegate(Set<T> collection, ConvertingImpl converting) {
+	SetDelegate(Set<T> collection, ConvertingImpl converting,
+			InternalConverter c) {
 		delegate = collection;
 		convertingImpl = converting;
+		converter = c;
 	}
 
 	// Whenever a modification is made, the delegate is cloned and detached.
@@ -198,7 +201,7 @@ class SetDelegate<T> implements Set<T> {
 		@Override
 		public T next() {
 			Object obj = delegateIterator.next();
-			return (T) convertingImpl.convertCollectionValue(obj);
+			return (T) convertingImpl.convertCollectionValue(obj, converter);
 		}
 
 		@Override

--- a/org.osgi.util.converter/src/org/osgi/util/converter/TypeReference.java
+++ b/org.osgi.util.converter/src/org/osgi/util/converter/TypeReference.java
@@ -32,7 +32,8 @@ import org.osgi.annotation.versioning.ConsumerType;
  *
  * <pre>
  * List&lt;String&gt; result = converter.convert(Arrays.asList(1, 2, 3))
- * 		.to(new TypeReference&lt;List&lt;String&gt;&gt;() {});
+ * 		.to(new TypeReference&lt;List&lt;String&gt;&gt;() {
+ * 		});
  * </pre>
  *
  * @param <T> The target type for the conversion.
@@ -45,7 +46,8 @@ public class TypeReference<T> {
 	 * A {@link TypeReference} cannot be directly instantiated. To use it, it
 	 * has to be extended, typically as an anonymous inner class.
 	 */
-	protected TypeReference() {}
+	protected TypeReference() {
+	}
 
 	/**
 	 * Return the actual type of this Type Reference

--- a/org.osgi.util.converter/src/org/osgi/util/converter/package-info.java
+++ b/org.osgi.util.converter/src/org/osgi/util/converter/package-info.java
@@ -31,10 +31,10 @@
  * Example import for providers implementing the API in this package:
  * <p>
  * {@code  Import-Package: org.osgi.util.converter; version="[1.0,1.1)"}
- * 
+ *
  * @author $Id$
  */
-@Version("1.0.2")
+@Version("1.0.8")
 package org.osgi.util.converter;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
The Felix Community has agreed to migrating this codebase to Eclipse
(see https://www.mail-archive.com/dev%40felix.apache.org/msg52014.html)

This PR supersedes #228 by removing unnecessary changes (such as whitespace and removal of javadoc tags), formats the code to our formatting rules, and removes a number of compiler warning introduced by the contributed changes.

This fixes #227 and closes #228.