### PR TITLE
dmt tck: Use assertj to compare arrays

### DIFF
--- a/org.osgi.test.cases.dmt.tc4/src/org/osgi/test/cases/dmt/tc4/ext/util/ArrayAssert.java
+++ b/org.osgi.test.cases.dmt.tc4/src/org/osgi/test/cases/dmt/tc4/ext/util/ArrayAssert.java
@@ -17,10 +17,9 @@
  *******************************************************************************/
 package org.osgi.test.cases.dmt.tc4.ext.util;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
-import java.util.List;
+import org.assertj.core.api.ObjectArrayAssert;
 public class ArrayAssert {
 
 	public static void assertEquivalenceArrays(Object[] expected, Object[] actual) {
@@ -28,17 +27,14 @@ public class ArrayAssert {
 	}
 
 	public static void assertEquivalenceArrays(String message, Object[] expected, Object[] actual) {
-		if ((expected == null) || (actual == null)) {
-			assertTrue(expected == actual);
-			return;
+		ObjectArrayAssert<Object> assertion = assertThat(actual);
+		if (message != null) {
+			assertion = assertion.as("%s", message);
 		}
-		List<Object> actualList = Arrays.asList(actual);
-		for (int i = 0; i < expected.length; i++) {
-			if (message != null) {
-				assertTrue(message, actualList.contains(expected[i]));
-			} else {
-				assertTrue(actualList.contains(expected[i]));
-			}
+		if (expected == null) {
+			assertion.isNull();
+		} else {
+			assertion.contains(expected);
 		}
 	}
 }


### PR DESCRIPTION
This is to try and capture an intermittent failure.

Related to #249.