### PR TITLE
Move explicit target property after explicit reference

### DIFF
--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb32/components.xml
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb32/components.xml
@@ -65,13 +65,13 @@
                 interface="org.osgi.test.cases.component.service.BaseService" />
         </service>
         <property name="type" value="condition_custom_reference" />
-        <!-- This property takes precedence over the target attribute of the reference -->
-        <property name="osgi.ds.satisfying.condition.target" value="(osgi.condition.id=condition_custom_reference)" />
         <reference name="osgi.ds.satisfying.condition"
           interface="org.osgi.service.condition.Condition"
           target="(osgi.condition.id=true)"
           policy="dynamic"
           field="serviceField"/>
+        <!-- This property takes precedence over the target attribute of the reference -->
+        <property name="osgi.ds.satisfying.condition.target" value="(osgi.condition.id=condition_custom_reference)" />
     </component>
 
 </components>


### PR DESCRIPTION
Related to #257

This updates the test to place the property for overriding the target of the explicit reference for the satisfying condition.  This should only be merged if we agree to the solution proposed in #257