### PR TITLE
[Feature] FeatureExtention.getArtifacts returns List<FeatureArtifact>

### DIFF
--- a/org.osgi.service.feature/src/org/osgi/service/feature/FeatureExtension.java
+++ b/org.osgi.service.feature/src/org/osgi/service/feature/FeatureExtension.java
@@ -114,5 +114,5 @@ public interface FeatureExtension {
      * Get the Artifacts from this extension.
      * @return The Artifacts, or {@code null} if this is not an Artifacts extension.
      */
-    List<ID> getArtifacts();
+    List<FeatureArtifact> getArtifacts();
 }


### PR DESCRIPTION
When calling `getArtifacts` on `FeatureExtention.class` it should return a `List<FeatureArtifact>` and not ` List<ID>`.
[#spec](https://osgi.github.io/osgi/cmpn/service.features.html#d0e156815)
_*FeatureArtifact have a ID and additional MetaData_
