### PR TITLE
build: Bump assertj-core from 3.20.1 to 3.20.2

### DIFF
--- a/cnf/ext/junit.bnd
+++ b/cnf/ext/junit.bnd
@@ -1,4 +1,4 @@
 junit-jupiter.version=5.7.2
 junit-platform.version=1.7.2
-assertj.version=3.20.1
+assertj.version=3.20.2
 osgi-test.version=1.0.0-SNAPSHOT


### PR DESCRIPTION
This reverts the API change to return concrete assert types.
