### PR TITLE
Exclude Bundle-Developers from the comparison in the test

### DIFF
--- a/org.osgi.test.cases.rest.client.js/src/org/osgi/test/cases/rest/client/js/junit/RestJSClientTestCase.java
+++ b/org.osgi.test.cases.rest.client.js/src/org/osgi/test/cases/rest/client/js/junit/RestJSClientTestCase.java
@@ -413,6 +413,11 @@ public class RestJSClientTestCase extends RestTestUtils {
 				+ "  success : function(res) {");
 
 		for (String key : Collections.list(headers.keys())) {
+			if ("Bundle-Developers".equals(key))
+				// The Bundle-Developers key can cause issues with this test due
+				// to potential unicode characters
+				continue;
+
 			sb.append("assert('header " + key + "', '" + headers.get(key) + "', res['" + key + "']);");
 		}
 				


### PR DESCRIPTION
This header could contain special characters that can cause issues.

Fixes #250

Signed-off-by: David Bosschaert <bosschae@adobe.com>