### PR TITLE
Use a FeatureArtifact to build extensions of type artifact

### DIFF
--- a/org.osgi.service.feature/src/org/osgi/service/feature/FeatureArtifactBuilder.java
+++ b/org.osgi.service.feature/src/org/osgi/service/feature/FeatureArtifactBuilder.java
@@ -41,10 +41,10 @@ public interface FeatureArtifactBuilder {
 	 * Add metadata for this Artifact by providing a map. All metadata in the
 	 * map is added to any previously provided metadata.
 	 * 
-	 * @param md The map with metadata.
+	 * @param metadata The map with metadata.
 	 * @return This builder.
 	 */
-	FeatureArtifactBuilder addMetadata(Map<String,Object> md);
+	FeatureArtifactBuilder addMetadata(Map<String,Object> metadata);
 
 	/**
 	 * Build the Artifact object. Can only be called once on a builder. After

--- a/org.osgi.service.feature/src/org/osgi/service/feature/FeatureBundleBuilder.java
+++ b/org.osgi.service.feature/src/org/osgi/service/feature/FeatureBundleBuilder.java
@@ -40,10 +40,10 @@ public interface FeatureBundleBuilder {
      * Add metadata for this Bundle by providing a map. All
      * metadata in the map is added to any previously provided
      * metadata.
-     * @param md The map with metadata.
+     * @param metadata The map with metadata.
      * @return This builder.
      */
-    FeatureBundleBuilder addMetadata(Map<String, Object> md);
+    FeatureBundleBuilder addMetadata(Map<String, Object> metadata);
 
     /**
      * Build the Bundle object. Can only be called once on a builder. After

--- a/org.osgi.service.feature/src/org/osgi/service/feature/FeatureConfigurationBuilder.java
+++ b/org.osgi.service.feature/src/org/osgi/service/feature/FeatureConfigurationBuilder.java
@@ -39,12 +39,13 @@ public interface FeatureConfigurationBuilder {
     FeatureConfigurationBuilder addValue(String key, Object value);
 
     /**
-     * Add a map of configuration values for this Configuration object. All values
-     * will be added to any previously provided configuration values.
-     * @param cfg
-     * @return This builder.
-     */
-    FeatureConfigurationBuilder addValues(Map<String, Object> cfg);
+	 * Add a map of configuration values for this Configuration object. All
+	 * values will be added to any previously provided configuration values.
+	 * 
+	 * @param configValues The map of configuration values to add.
+	 * @return This builder.
+	 */
+    FeatureConfigurationBuilder addValues(Map<String, Object> configValues);
 
     /**
      * Build the Configuration object. Can only be called once on a builder. After

--- a/org.osgi.service.feature/src/org/osgi/service/feature/FeatureExtensionBuilder.java
+++ b/org.osgi.service.feature/src/org/osgi/service/feature/FeatureExtensionBuilder.java
@@ -48,34 +48,10 @@ public interface FeatureExtensionBuilder {
 	 * Add an Artifact to the extension. Can only be called for extensions of
 	 * type {@link FeatureExtension.Type#ARTIFACTS}.
 	 *
-	 * @param aid The ArtifactID of the artifact to add.
+	 * @param art The artifact to add.
 	 * @return This builder.
 	 */
-    FeatureExtensionBuilder addArtifact(ID aid);
-
-    /**
-	 * Add an Artifact to the extension. Can only be called for extensions of
-	 * type {@link FeatureExtension.Type#ARTIFACTS}.
-	 *
-	 * @param groupId The Group ID of the artifact to add.
-	 * @param artifactId The Artifact ID of the artifact to add.
-	 * @param version The Version of the artifact to add.
-	 * @return This builder.
-	 */
-    FeatureExtensionBuilder addArtifact(String groupId, String artifactId, String version);
-
-    /**
-	 * Add an Artifact to the extension. Can only be called for extensions of
-	 * type {@link FeatureExtension.Type#ARTIFACTS}.
-	 *
-	 * @param groupId The Group ID of the artifact to add.
-	 * @param artifactId The Artifact ID of the artifact to add.
-	 * @param version The Version of the artifact to add.
-	 * @param type The type indicator of the artifact to add.
-	 * @param classifier The classifier of the artifact to add.
-	 * @return This builder.
-	 */
-    FeatureExtensionBuilder addArtifact(String groupId, String artifactId, String version, String type, String classifier);
+	FeatureExtensionBuilder addArtifact(FeatureArtifact art);
 
     /**
      * Build the Extension. Can only be called once on a builder. After

--- a/org.osgi.service.feature/src/org/osgi/service/feature/FeatureExtensionBuilder.java
+++ b/org.osgi.service.feature/src/org/osgi/service/feature/FeatureExtensionBuilder.java
@@ -48,10 +48,10 @@ public interface FeatureExtensionBuilder {
 	 * Add an Artifact to the extension. Can only be called for extensions of
 	 * type {@link FeatureExtension.Type#ARTIFACTS}.
 	 *
-	 * @param art The artifact to add.
+	 * @param artifact The artifact to add.
 	 * @return This builder.
 	 */
-	FeatureExtensionBuilder addArtifact(FeatureArtifact art);
+	FeatureExtensionBuilder addArtifact(FeatureArtifact artifact);
 
     /**
      * Build the Extension. Can only be called once on a builder. After


### PR DESCRIPTION
This is consistent with the return of objects of type FeatureArtifact
already done by FeatureExtension.getArtifacts()

Signed-off-by: David Bosschaert <bosschae@adobe.com>