### PR TITLE
build: Set rootProject.name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -33,6 +33,7 @@ pluginManagement {
 		mavenCentral()
 		gradlePluginPortal()
 	}
+	rootProject.name = "osgi"
 	gradle.ext.bndWorkspaceConfigure = { workspace ->
 		// In case these are set from the command line...
 		workspace.setProperty("bnd_version", bnd_version)


### PR DESCRIPTION
This is a gradle best practice.

