### PR TITLE
tck.dmt4: Add a small delay before starting test methods

### DIFF
--- a/org.osgi.test.cases.dmt.tc4/src/org/osgi/test/cases/dmt/tc4/ext/junit/InternalChangedEventTest.java
+++ b/org.osgi.test.cases.dmt.tc4/src/org/osgi/test/cases/dmt/tc4/ext/junit/InternalChangedEventTest.java
@@ -33,6 +33,7 @@ import org.osgi.test.cases.dmt.tc4.ext.util.ArrayAssert;
 import org.osgi.test.cases.dmt.tc4.ext.util.TestDataMountPlugin;
 import org.osgi.test.cases.dmt.tc4.ext.util.TestDmtEventListener;
 import org.osgi.test.cases.dmt.tc4.ext.util.TestEventHandler;
+import org.osgi.test.support.sleep.Sleep;
 
 public class InternalChangedEventTest extends DmtAdminTestCase {
 
@@ -49,6 +50,7 @@ public class InternalChangedEventTest extends DmtAdminTestCase {
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
+		Sleep.sleep(250L);
 		getDmtAdmin();
 	}
 


### PR DESCRIPTION
This is an attempt to avoid having a test method observe events
generated by a previous test method. So we put some time between the
test methods.

See https://github.com/osgi/osgi/issues/249
