### PR TITLE
[Features] Remove security section from spec text

### DIFF
--- a/osgi.specs/docbook/159/service.feature.xml
+++ b/osgi.specs/docbook/159/service.feature.xml
@@ -783,13 +783,6 @@ Feature f = builder.build();</programlisting>
     Feature Resource Version is specified <code>1.0</code> is used as the default.
     </para>
   </section>
-  
-  <section>
-    <title>Security</title>
-
-    <para>
-    ...</para>
-  </section>
 
   <xi:include href="../../generated/javadoc/docbook/org.osgi.service.feature.xml"/>
 


### PR DESCRIPTION
Regular service lookup security rules apply for the FeatureService. This
does not need to be written down explicity as it is inherent to running
OSGi with a security manager.

Signed-off-by: David Bosschaert <bosschae@adobe.com>