### PR TITLE
Using Temurin builds of OpenJDK in GH actions

### DIFF
--- a/.github/workflows/bnd-test.yml
+++ b/.github/workflows/bnd-test.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ env.java_version }}
     - name: Build
       id: build

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ env.java_version }}
     - name: Build
       id: build
@@ -105,7 +105,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ env.java_version }}
     - name: Build
       id: build
@@ -145,7 +145,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ env.java_version }}
     - name: Download TCK
       uses: actions/download-artifact@v2


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued Since July 2021. When using Zulu you get all the latest updated TCK tested builds for all versions of OpenJDK.