### PR TITLE
build: Prepare build for RC1 build

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -73,7 +73,7 @@ osgi.annotation.version=8.0.0
 
 # Documentation
 -groupid: org.osgi
--pom: version=${versionmask;===s;${@version}}
+-pom: version=${if;${def;-snapshot};${versionmask;===;${@version}}-${-snapshot};${versionmask;===s;${@version}}}
 Bundle-Name: ${-groupid}:${bsn}
 Bundle-Copyright: ${copyright}
 Bundle-Vendor:    Eclipse Foundation

--- a/cnf/ext/repositories.bnd
+++ b/cnf/ext/repositories.bnd
@@ -43,6 +43,6 @@ publishrepo: ${if;${env;OSSRH_USERNAME};OSGiNexus}
 -connection-settings.publish: ${if;${publishrepo};${.}/ossrh-settings.xml}
 
 -buildrepo: Local
--releaserepo: Release,${def;-snapshot;${publishrepo}}
+-releaserepo: Release,${if;${is;${def;-snapshot;UNSET};UNSET};${publishrepo}}
 -baselinerepo: Baseline
 -maven-release: pom;path=JAR,javadoc;path=NONE,sources;path=NONE


### PR DESCRIPTION
We change the build to allow using -snapshot to specify the RC1
qualifier.

* -snapshot unset is a snapshot build
* -snapshot set to RC1 is a release build of RC1
* -snapshot set to the empty string is a release build

