### PR TITLE
tck: Fix JNDI TCK's boot delegation

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -110,7 +110,8 @@ Bundle-License: ${SPDX-License-Identifier};\
 
 -runtrace=true
 runproperties = report=true, \
- equinox.use.ds=true
+ equinox.use.ds=true, \
+ org.osgi.framework.bootdelegation="${org.osgi.framework.bootdelegation.*}"
 runsecureproperties = ${runproperties}, \
 	org.osgi.framework.security=osgi, \
 	org.osgi.framework.trust.repositories=${build}/keystore

--- a/cnf/osgi.tck.junit-platform.bnd
+++ b/cnf/osgi.tck.junit-platform.bnd
@@ -16,5 +16,4 @@ testcases.junit5 = ${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.c
 Test-Cases: ${sort;${uniq;${testcases.junit3};${testcases.junit4};${testcases.junit5}}}
 
 #for mockito
--runproperties.osgi.tck: \
-	org.osgi.framework.bootdelegation=sun.reflect 
+org.osgi.framework.bootdelegation.mockito=sun.misc,sun.reflect

--- a/org.osgi.impl.bundle.annotations/bnd.bnd
+++ b/org.osgi.impl.bundle.annotations/bnd.bnd
@@ -9,5 +9,3 @@ Bundle-Description			= Annotations Test Bundle
 	org.osgi.annotation.bundle; version=latest, \
 	org.osgi.annotation.versioning; version=latest
 
--runproperties = ${runproperties}
-

--- a/org.osgi.impl.bundle.metatype.annotations/bnd.bnd
+++ b/org.osgi.impl.bundle.metatype.annotations/bnd.bnd
@@ -18,6 +18,3 @@ Bundle-Description			= Metatype Annotations Test Bundle
 	org.osgi.impl.service.metatype; version=latest, \
 	org.osgi.impl.service.cm; version=latest, \
 	org.osgi.impl.service.log; version=latest
-	
--runproperties = ${runproperties}
-

--- a/org.osgi.impl.service.rest/bnd.bnd
+++ b/org.osgi.impl.service.rest/bnd.bnd
@@ -23,5 +23,4 @@ Provide-Capability: osgi.implementation; \
 -runbundles = \
 	org.osgi.impl.service.rest.support; version=latest
 	
--runproperties = ${runproperties}, \
-	org.osgi.framework.bootdelegation="sun.*,com.sun.*"
+org.osgi.framework.bootdelegation=sun.*,com.sun.*

--- a/org.osgi.test.cases.async/bnd.bnd
+++ b/org.osgi.test.cases.async/bnd.bnd
@@ -22,8 +22,6 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.service.async;version=latest,\
 	org.osgi.impl.service.async;version=latest
 
--runproperties = ${runproperties}
-
 -signaturetest                      = \
  org.osgi.service.async, \
  org.osgi.service.async.delegate

--- a/org.osgi.test.cases.cdi.secure/bnd.bnd
+++ b/org.osgi.test.cases.cdi.secure/bnd.bnd
@@ -40,8 +40,7 @@ Bundle-Description: Secure TCK for the OSGi/CDI integration
 -runsystemcapabilities: \
 	osgi.implementation;osgi.implementation="osgi.cm";uses:="org.osgi.service.cm,org.apache.felix.cm";version:Version="1.6"
 
--runproperties: \
-	${runsecureproperties},\
+-runproperties: ${runsecureproperties},\
 	eclipse.consoleLog=true,\
 	eclipse.log.level=DEBUG
 

--- a/org.osgi.test.cases.cdi/bnd.bnd
+++ b/org.osgi.test.cases.cdi/bnd.bnd
@@ -62,8 +62,7 @@ Import-Package: ${-signaturetest}, *
 -runbundles: \
 	org.osgi.impl.bundle.cdi;version=latest
 
--runproperties: \
-	${runproperties},\
+-runproperties: ${runproperties},\
 	eclipse.consoleLog=true,\
 	eclipse.log.level=DEBUG
 

--- a/org.osgi.test.cases.clusterinfo/bnd.bnd
+++ b/org.osgi.test.cases.clusterinfo/bnd.bnd
@@ -27,5 +27,3 @@ Import-Package: ${-signaturetest}, *
 -runbundles = \
     org.osgi.impl.service.clusterinfo;version=latest, \
     org.osgi.impl.service.log;version=latest
-
--runproperties = ${runproperties}

--- a/org.osgi.test.cases.converter/bnd.bnd
+++ b/org.osgi.test.cases.converter/bnd.bnd
@@ -21,5 +21,3 @@ Import-Package: ${-signaturetest}, *
 -runbundles: \
 	org.osgi.util.converter;version=latest, \
     org.osgi.util.function;version=latest
-
--runproperties = ${runproperties}

--- a/org.osgi.test.cases.dal.functions/bnd.bnd
+++ b/org.osgi.test.cases.dal.functions/bnd.bnd
@@ -27,8 +27,6 @@ Export-Package: org.osgi.test.support.step;-noimport:=true;-split-package:=first
 	org.osgi.impl.service.dal.step;	version=latest, \
 	org.osgi.impl.service.event;	version=latest
 
--runproperties = ${runproperties}
-
 -signaturetest	= \
 	org.osgi.service.dal.functions, \
 	org.osgi.service.dal.functions.data

--- a/org.osgi.test.cases.dal/bnd.bnd
+++ b/org.osgi.test.cases.dal/bnd.bnd
@@ -24,6 +24,4 @@ Export-Package: org.osgi.test.support.step;-noimport:=true, \
 	org.osgi.impl.service.dal.step;	version=latest, \
 	org.osgi.impl.service.event;	version=latest
 
--runproperties = ${runproperties}
-
 -signaturetest	= org.osgi.service.dal

--- a/org.osgi.test.cases.event/bnd.bnd
+++ b/org.osgi.test.cases.event/bnd.bnd
@@ -29,7 +29,3 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.impl.service.cm; version=latest, \
 	org.osgi.impl.service.event; version=latest, \
 	org.osgi.impl.service.log; version=latest
-	
-
-
--runproperties = ${runproperties}

--- a/org.osgi.test.cases.jaxrs/bnd.bnd
+++ b/org.osgi.test.cases.jaxrs/bnd.bnd
@@ -37,8 +37,6 @@ Import-Package: ${-signaturetest},\
     org.osgi.impl.service.cm;version=latest,\
     org.osgi.impl.service.jaxrs;version=latest
 
--runproperties                  = ${runproperties}
-
 -signaturetest                      = org.osgi.service.jaxrs.runtime,\
                                       org.osgi.service.jaxrs.runtime.dto,\
                                       org.osgi.service.jaxrs.whiteboard

--- a/org.osgi.test.cases.jdbc/bnd.bnd
+++ b/org.osgi.test.cases.jdbc/bnd.bnd
@@ -17,6 +17,4 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.impl.service.jdbc; version=latest, \
 	org.osgi.impl.bundle.derby; version=latest
 
--runproperties					= ${runproperties}
-
 -signaturetest                      = org.osgi.service.jdbc

--- a/org.osgi.test.cases.jndi.secure/bnd.bnd
+++ b/org.osgi.test.cases.jndi.secure/bnd.bnd
@@ -29,5 +29,5 @@ Import-Package 						= \
     org.osgi.service.jndi;version=latest, \
 	org.osgi.impl.service.jndi; version=latest
 
--runproperties = ${runsecureproperties}, \
-	org.osgi.framework.bootdelegation=com.sun.*
+org.osgi.framework.bootdelegation=com.sun.*
+-runproperties = ${runsecureproperties}

--- a/org.osgi.test.cases.jndi/bnd.bnd
+++ b/org.osgi.test.cases.jndi/bnd.bnd
@@ -43,5 +43,4 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.service.jndi;version=latest, \
 	org.osgi.impl.service.jndi; version=latest
 
--runproperties = ${runproperties}, \
-	org.osgi.framework.bootdelegation=com.sun.*
+org.osgi.framework.bootdelegation=com.sun.*

--- a/org.osgi.test.cases.jpa/bnd.bnd
+++ b/org.osgi.test.cases.jpa/bnd.bnd
@@ -51,6 +51,4 @@ Import-Package						= \
 	org.osgi.impl.service.jpa; version=latest, \
     org.osgi.impl.service.jdbc.support; version=latest
 
--runproperties					= ${runproperties}
-
 -signaturetest                      = org.osgi.service.jpa

--- a/org.osgi.test.cases.log/bnd.bnd
+++ b/org.osgi.test.cases.log/bnd.bnd
@@ -21,7 +21,5 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.impl.service.log;version=latest,\
 	org.osgi.impl.service.cm;version=latest
 
--runproperties					= ${runproperties}
-
 -includeresource 					= \
 	tb1.jar

--- a/org.osgi.test.cases.metatype/bnd.bnd
+++ b/org.osgi.test.cases.metatype/bnd.bnd
@@ -37,5 +37,3 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.impl.service.cm; version=latest, \
 	org.osgi.impl.service.log; version=latest, \
 	org.osgi.impl.service.metatype; version=latest
-
--runproperties = ${runproperties}

--- a/org.osgi.test.cases.networkadapter/bnd.bnd
+++ b/org.osgi.test.cases.networkadapter/bnd.bnd
@@ -20,7 +20,5 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.impl.service.networkadapter;version=latest,\
 	org.osgi.impl.service.event;version=latest
 
--runproperties = ${runproperties}
-
 Export-Package:  \
 	org.osgi.test.support.step

--- a/org.osgi.test.cases.onem2m/bnd.bnd
+++ b/org.osgi.test.cases.onem2m/bnd.bnd
@@ -24,5 +24,4 @@ Bundle-Description: Tests the service layer bundle
 	org.osgi.service.onem2m;version=latest,\
 	org.osgi.impl.service.onem2m;version=latest
 
--runproperties: ${runproperties},\
-	org.osgi.framework.bootdelegation=*
+org.osgi.framework.bootdelegation=*

--- a/org.osgi.test.cases.prefs/bnd.bnd
+++ b/org.osgi.test.cases.prefs/bnd.bnd
@@ -18,5 +18,3 @@ Import-Package: ${-signaturetest}, *
 -runbundles = \
     org.osgi.service.prefs;version=latest, \
 	org.osgi.impl.service.prefs; version=latest
-
--runproperties = ${runproperties}

--- a/org.osgi.test.cases.promise/bnd.bnd
+++ b/org.osgi.test.cases.promise/bnd.bnd
@@ -13,5 +13,3 @@ Import-Package: ${-signaturetest}, *
 -buildpath = \
     org.osgi.test.support;version=project, \
     org.osgi.framework;maven-scope=provided;version=1.8
-
--runproperties = ${runproperties}

--- a/org.osgi.test.cases.pushstream/bnd.bnd
+++ b/org.osgi.test.cases.pushstream/bnd.bnd
@@ -17,5 +17,3 @@ Import-Package: ${-signaturetest}, *
 
 -runbundles = \
 	org.osgi.util.pushstream;version=latest
-
--runproperties = ${runproperties}

--- a/org.osgi.test.cases.repository/bnd.bnd
+++ b/org.osgi.test.cases.repository/bnd.bnd
@@ -29,5 +29,3 @@ Import-Package: ${-signaturetest}, *
 -signaturetest                      = \
     org.osgi.service.repository
 
--runproperties = ${runproperties}
-

--- a/org.osgi.test.cases.resolver/bnd.bnd
+++ b/org.osgi.test.cases.resolver/bnd.bnd
@@ -58,5 +58,3 @@ Import-Package: ${-signaturetest}, *
 
 -runbundles = \
 	org.osgi.impl.service.resolver; version=latest
-	
--runproperties = ${runproperties}

--- a/org.osgi.test.cases.rest.client.js/bnd.bnd
+++ b/org.osgi.test.cases.rest.client.js/bnd.bnd
@@ -38,8 +38,8 @@ Import-Package: javax.*;org.apache.*;org.eclipse.jetty.*;org.ietf.*;org.slf4j.*;
     org.osgi.impl.service.rest.client.js; version=latest, \
     org.osgi.impl.service.rest.support; version=latest
 
+org.osgi.framework.bootdelegation=sun.*,com.sun.*
 -runproperties = ${runproperties}, \
-    org.osgi.framework.bootdelegation="sun.*,com.sun.*", \
     rest.tck.debug=false
 #  rest.tck.not_acceptable.check=false,\
 #  rest.tck.validate.xmls=false,\

--- a/org.osgi.test.cases.rest.client/bnd.bnd
+++ b/org.osgi.test.cases.rest.client/bnd.bnd
@@ -36,8 +36,8 @@ Bundle-Category: osgi,test
     org.osgi.impl.service.rest.support;version=latest, \
     org.osgi.impl.service.rest.client;version=latest
 
+org.osgi.framework.bootdelegation=sun.*,com.sun.*
 -runproperties = ${runproperties}, \
-    org.osgi.framework.bootdelegation="sun.*,com.sun.*", \
     rest.tck.debug=false
 #  rest.tck.not_acceptable.check=false,\
 #  rest.tck.validate.xmls=false,\

--- a/org.osgi.test.cases.rest/bnd.bnd
+++ b/org.osgi.test.cases.rest/bnd.bnd
@@ -37,8 +37,8 @@ Bundle-Category: osgi,test
     org.osgi.impl.service.rest; version=latest, \
     org.osgi.impl.service.rest.support; version=latest
 
+org.osgi.framework.bootdelegation=sun.*,com.sun.*
 -runproperties = ${runproperties}, \
-    org.osgi.framework.bootdelegation="sun.*,com.sun.*", \
     rest.tck.base.uri="http://localhost:8888/",\
     rest.tck.debug=false
 #  rest.tck.not_acceptable.check=false,\

--- a/org.osgi.test.cases.serial/bnd.bnd
+++ b/org.osgi.test.cases.serial/bnd.bnd
@@ -22,5 +22,3 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.service.serial;version=latest,\
 	org.osgi.impl.service.serial;version=latest,\
 	org.osgi.impl.service.event;version=latest
-
--runproperties = ${runproperties}

--- a/org.osgi.test.cases.serviceloader/bnd.bnd
+++ b/org.osgi.test.cases.serviceloader/bnd.bnd
@@ -40,5 +40,3 @@ Bundle-Category: osgi,test
 
 -runbundles = \
 	org.osgi.impl.bundle.serviceloader;version=latest
-
--runproperties: ${runproperties}

--- a/org.osgi.test.cases.tr069todmt/bnd.bnd
+++ b/org.osgi.test.cases.tr069todmt/bnd.bnd
@@ -22,6 +22,4 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.impl.service.dmt;version=latest, \
 	org.osgi.impl.service.tr069todmt;version=latest
 
--runproperties = ${runproperties}
-
 -signaturetest                      = org.osgi.service.tr069todmt

--- a/org.osgi.test.cases.tracker/bnd.bnd
+++ b/org.osgi.test.cases.tracker/bnd.bnd
@@ -16,9 +16,7 @@ Export-Package						= ${p}.service
 # The following tests the tracker code from the org.osgi.util.tracker 
 # project instead of the one in the framework RI.
 -runpath = org.osgi.util.tracker;version=latest
--runbundles = 
-
--runproperties						= ${runproperties}
+-runbundles =
 
 -signaturetest                      = org.osgi.util.tracker
 

--- a/org.osgi.test.cases.transaction.control.jdbc/bnd.bnd
+++ b/org.osgi.test.cases.transaction.control.jdbc/bnd.bnd
@@ -25,6 +25,4 @@ Export-Package: org.osgi.service.transaction.control, \
 	org.osgi.impl.service.transaction.control.jdbc; version=latest, \
     org.osgi.impl.service.jdbc.support; version=latest
 
--runproperties = ${runproperties}
-
 -signaturetest                      = org.osgi.service.transaction.control.jdbc

--- a/org.osgi.test.cases.transaction.control.jpa/bnd.bnd
+++ b/org.osgi.test.cases.transaction.control.jpa/bnd.bnd
@@ -29,6 +29,4 @@ javac.profile=compact2
 	org.osgi.impl.service.transaction.control.jpa; version=latest, \
     org.osgi.impl.service.jdbc.support; version=latest
 
--runproperties = ${runproperties}
-
 -signaturetest                      = org.osgi.service.transaction.control.jpa

--- a/org.osgi.test.cases.typedevent/bnd.bnd
+++ b/org.osgi.test.cases.typedevent/bnd.bnd
@@ -22,7 +22,4 @@ Import-Package: ${-signaturetest}, *
     org.osgi.impl.service.cm;version=latest, \
 	org.osgi.impl.service.typedevent;version=latest
 
--runproperties = ${runproperties}
-
 -signaturetest                      = org.osgi.service.typedevent
-

--- a/org.osgi.test.cases.url/bnd.bnd
+++ b/org.osgi.test.cases.url/bnd.bnd
@@ -17,5 +17,3 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.service.url;maven-scope=provided;version=latest
 
 -runbundles =
-
--runproperties = ${runproperties}

--- a/org.osgi.test.cases.usbinfo/bnd.bnd
+++ b/org.osgi.test.cases.usbinfo/bnd.bnd
@@ -24,5 +24,3 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.impl.service.usbinfo;version=latest,\
 	org.osgi.impl.service.device.manager;version=latest,\
 	org.osgi.impl.service.event;version=latest
-
--runproperties = ${runproperties}

--- a/org.osgi.test.cases.useradmin/bnd.bnd
+++ b/org.osgi.test.cases.useradmin/bnd.bnd
@@ -19,5 +19,3 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.service.useradmin;version=latest, \
 	org.osgi.impl.service.log;version=latest, \
 	org.osgi.impl.service.useradmin;version=latest
-
--runproperties = ${runproperties}

--- a/org.osgi.test.cases.webcontainer/bnd.bnd
+++ b/org.osgi.test.cases.webcontainer/bnd.bnd
@@ -54,8 +54,8 @@ Export-Package =\
 	org.osgi.impl.service.event; 		version=latest, \
     org.osgi.impl.bundle.webcontainer; version=latest
 
+org.osgi.framework.bootdelegation=sun.*,com.sun.*
 -runproperties = ${runproperties}, \
-    org.osgi.framework.bootdelegation="sun.*,com.sun.*", \
 	org.osgi.service.webcontainer.hostname=127.0.0.1, \
 	org.osgi.service.webcontainer.http.port=8080, \
 	org.osgi.test.testcase.timeout=10000, \

--- a/org.osgi.test.cases.xml/bnd.bnd
+++ b/org.osgi.test.cases.xml/bnd.bnd
@@ -26,5 +26,4 @@ Bundle-Activator = org.osgi.util.xml.XMLParserActivator
 -runbundles = \
     org.osgi.util.xml; version=latest
 
--runproperties = ${runproperties}
 -fixupmessages.activator: "Bundle-Activator * is being imported into the bundle"


### PR DESCRIPTION
The change to add mockito caused the org.osgi.framework.bootdelegation
properties in a TCK to be overriden. So we move to use a merged
property for the bootdelegation values and then merge them into the
-runproperties.

