### PR TITLE
run CDI TCK using latest snapshot build of Aries CDI (1.1.4-SNAPSHOT)

### DIFF
--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -85,11 +85,11 @@ javax.ejb:javax.ejb-api:3.2
 javax.transaction:javax.transaction-api:1.2
 
 org.apache.aries:org.apache.aries.util:1.1.3
-org.apache.aries.cdi:org.apache.aries.cdi.extender:1.1.3
-org.apache.aries.cdi:org.apache.aries.cdi.extension.spi:1.1.3
-org.apache.aries.cdi:org.apache.aries.cdi.extra:1.1.3
-org.apache.aries.cdi:org.apache.aries.cdi.spi:1.1.3
-org.apache.aries.cdi:org.apache.aries.cdi.weld:1.1.3
+org.apache.aries.cdi:org.apache.aries.cdi.extender:1.1.4-SNAPSHOT
+org.apache.aries.cdi:org.apache.aries.cdi.extension.spi:1.1.4-SNAPSHOT
+org.apache.aries.cdi:org.apache.aries.cdi.extra:1.1.4-SNAPSHOT
+org.apache.aries.cdi:org.apache.aries.cdi.spi:1.1.4-SNAPSHOT
+org.apache.aries.cdi:org.apache.aries.cdi.weld:1.1.4-SNAPSHOT
 org.apache.aries.jax.rs:org.apache.aries.jax.rs.whiteboard:1.0.4
 org.apache.aries.jpa:org.apache.aries.jpa.eclipselink.adapter:2.4.0
 org.apache.aries.spec:org.apache.aries.javax.jax.rs-api:1.0.4


### PR DESCRIPTION
which attempts to solve https://issues.apache.org/jira/browse/ARIES-2059 that I think is the issue which makes the OSGi CDI TCK unstable

Signed-off-by: Raymond Augé <raymond.auge@liferay.com>