### PR TITLE
[RSA] Ensure the TCK has visibility of endpoint changes before continuing

### DIFF
--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/DiscoveryTest.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/DiscoveryTest.java
@@ -878,8 +878,8 @@ public class DiscoveryTest extends MultiFrameworkTestCase {
 			lastMatchedFilter = matchedFilter;
 
 			if (EndpointEvent.ADDED == event.getType()) {
-				semAdded.release();
 				lastAddedEndpoint = event.getEndpoint();
+				semAdded.release();
 			}
 
 			if (EndpointEvent.MODIFIED == event.getType()) {
@@ -891,8 +891,8 @@ public class DiscoveryTest extends MultiFrameworkTestCase {
 			}
 
 			if (EndpointEvent.REMOVED == event.getType()) {
-				semRemoved.release();
 				lastRemovedEndpoint = event.getEndpoint();
+				semRemoved.release();
 			}
 		}
 


### PR DESCRIPTION
When using EndpointEvents the TCK is releasing the semaphore before storing the changed endpoint. This means the endpoint may not be available on semaphore release, and even if it is available the memory modification is not guaranteed to be visible to the waiting thread.

Signed-off-by: Tim Ward <timothyjward@apache.org>