### PR TITLE
Publish only updated

### DIFF
--- a/cnf/annotation.bnd
+++ b/cnf/annotation.bnd
@@ -1,6 +1,8 @@
 # bnd instructions for Annotation projects
 
-# Uncomment the following line to build the non-snapshot version.
+# -snapshot unset (commented out) is a snapshot build. (e.g. 6.0.0-SNAPSHOT)
+# -snapshot set to a value (e.g. RC1) is a release build with the value as the Maven version qualifier. (e.g. 6.0.0-RC1)
+# -snapshot set to the empty string is a release build with no Maven version qualifier. (e.g. 6.0.0)
 #-snapshot:
 
 packaging: annotation

--- a/cnf/cmpn.bnd
+++ b/cnf/cmpn.bnd
@@ -1,6 +1,8 @@
 # bnd instructions for Compendium projects
 
-# Uncomment the following line to build the non-snapshot version.
+# -snapshot unset (commented out) is a snapshot build. (e.g. 6.0.0-SNAPSHOT)
+# -snapshot set to a value (e.g. RC1) is a release build with the value as the Maven version qualifier. (e.g. 6.0.0-RC1)
+# -snapshot set to the empty string is a release build with no Maven version qualifier. (e.g. 6.0.0)
 #-snapshot:
 
 packaging: cmpn

--- a/cnf/companion.bnd
+++ b/cnf/companion.bnd
@@ -1,10 +1,9 @@
-# bnd instructions for companion code projects
+# Bnd instructions for companion code projects
+-include: ${.}/publish.bnd
+companion.code = true
+
 spec.package.versionattr: ${packageattribute;${def;spec.package;${bsn}};version}
 spec.version = ${versionmask;===;${first;${spec.package.versionattr};0}}
 build.version = ${build.versionmask;${spec.version}}.${project.build}
 Automatic-Module-Name: ${bsn}
 Bundle-Description: OSGi Companion Code for ${bsn} Version ${spec.version}
--maven-release: pom;path=JAR,javadoc;path="${target}/docs/javadoc",${def;mavensign}
-
--baseline: *
-companion.code = true

--- a/cnf/core.bnd
+++ b/cnf/core.bnd
@@ -1,6 +1,8 @@
 # bnd instructions for Core projects
 
-# Uncomment the following line to build the non-snapshot version.
+# -snapshot unset (commented out) is a snapshot build. (e.g. 6.0.0-SNAPSHOT)
+# -snapshot set to a value (e.g. RC1) is a release build with the value as the Maven version qualifier. (e.g. 6.0.0-RC1)
+# -snapshot set to the empty string is a release build with no Maven version qualifier. (e.g. 6.0.0)
 #-snapshot:
 
 packaging: core

--- a/cnf/ext/baseline.mvn
+++ b/cnf/ext/baseline.mvn
@@ -24,6 +24,7 @@ org.osgi:org.osgi.service.device:1.1.0
 org.osgi:org.osgi.service.dmt:2.0.2
 org.osgi:org.osgi.service.enocean:1.0.0
 org.osgi:org.osgi.service.event:1.4.0
+#org.osgi:org.osgi.service.feature:1.0.0
 org.osgi:org.osgi.service.http:1.2.1
 org.osgi:org.osgi.service.http.whiteboard:1.1.0
 org.osgi:org.osgi.service.jaxrs:1.0.0
@@ -31,9 +32,11 @@ org.osgi:org.osgi.service.jdbc:1.0.0
 org.osgi:org.osgi.service.jndi:1.0.0
 org.osgi:org.osgi.service.jpa:1.1.0
 org.osgi:org.osgi.service.log:1.5.0
+#org.osgi:org.osgi.service.log.stream:1.0.0
 org.osgi:org.osgi.service.metatype:1.4.0
 org.osgi:org.osgi.service.metatype.annotations:1.4.0
 org.osgi:org.osgi.service.networkadapter:1.0.0
+#org.osgi:org.osgi.service.onem2m:1.0.0
 org.osgi:org.osgi.service.packageadmin:1.2.1
 org.osgi:org.osgi.service.permissionadmin:1.2.1
 org.osgi:org.osgi.service.prefs:1.1.1
@@ -47,6 +50,7 @@ org.osgi:org.osgi.service.serviceloader:1.0.0
 org.osgi:org.osgi.service.startlevel:1.1.1
 org.osgi:org.osgi.service.tr069todmt:1.0.1
 org.osgi:org.osgi.service.transaction.control:1.0.0
+#org.osgi:org.osgi.service.typedevent:1.0.0
 org.osgi:org.osgi.service.upnp:1.2.0
 org.osgi:org.osgi.service.url:1.0.1
 org.osgi:org.osgi.service.usbinfo:1.0.0

--- a/cnf/ext/repositories.bnd
+++ b/cnf/ext/repositories.bnd
@@ -43,7 +43,7 @@ publishrepo: ${if;${env;OSSRH_USERNAME};OSGiNexus}
 -connection-settings.publish: ${if;${publishrepo};${.}/ossrh-settings.xml}
 
 -buildrepo: Local
--releaserepo: Release,${publishrepo}
+-releaserepo: Release
 -baselinerepo: Baseline
+
 -maven-release: pom;path=JAR,javadoc;path=NONE,sources;path=NONE
-mavensign: ${if;${is;${env;GPG_PASSPHRASE;UNSET};UNSET};;sign\\;passphrase=${first;${env;GPG_PASSPHRASE};DEFAULT}}

--- a/cnf/gradle/companion.gradle
+++ b/cnf/gradle/companion.gradle
@@ -21,28 +21,27 @@
  */
 
 def jar = tasks.named("jar") {
-	def docsDirectory = objects.directoryProperty().value(layout.getBuildDirectory().dir(provider({-> project.docsDirName})))
-	ext.javadocIncludes = docsDirectory.file("javadocIncludes.txt")
-	ext.javadocVersion = docsDirectory.file("javadocVersion.txt")
+	ext.jarVersion = layout.getBuildDirectory().file("version.txt")
+	ext.javadocIncludes = project.java.getDocsDir().file("javadoc-includes.txt")
 	def projectName = project.getName()
 	def bndProject = bnd.project
 
+	outputs.file(jarVersion).withPropertyName("jarVersion")
 	outputs.file(javadocIncludes).withPropertyName("javadocIncludes")
-	outputs.file(javadocVersion).withPropertyName("javadocVersion")
 
 	doLast("javadoc-info") { t ->
+		File jarVersionFile = jarVersion.get().getAsFile()
+		def version = bndProject.getVersion(projectName)
+		jarVersionFile.text = bnd.process("\${versionmask;===s;${version}}")
 		File javadocIncludesFile = javadocIncludes.get().getAsFile()
 		javadocIncludesFile.text = bndProject.getExports().collect { packageRef, attrs ->
 			"${packageRef.getBinary()}/*.java"
 		}.join(",")
-		File javadocVersionFile = javadocVersion.get().getAsFile()
-		def version = bndProject.getVersion(projectName)
-		javadocVersionFile.text = bnd.process("\${versionmask;===s;${version}}")
 	}
 }
 
 def javadoc = tasks.named("javadoc") {
-	inputs.files(jar).withPropertyName("jar")
+	inputs.files(jar).withPropertyName(jar.name)
 	source(bnd.allSrcDirs)
 	def javadocTitle = bnd.get("javadoc.title", project.getName())
 	def copyrightHtml = bnd.get("copyright.html")
@@ -88,7 +87,7 @@ def javadoc = tasks.named("javadoc") {
 	}
 	doFirst("configuration") { t ->
 		def osgiRelease = bnd.get("osgi.release")
-		File javadocVersion = jar.flatMap({it.javadocVersion}).get().getAsFile()
+		File javadocVersion = jar.flatMap({it.jarVersion}).get().getAsFile()
 		File javadocIncludes = jar.flatMap({it.javadocIncludes}).get().getAsFile()
 		def javadocTitleVersion = project.getName().startsWith("osgi.") ? "Release ${osgiRelease}" : "Version ${javadocVersion.text}"
 		options.docTitle = "OSGi&reg; ${javadocTitle} ${javadocTitleVersion}"
@@ -96,7 +95,7 @@ def javadoc = tasks.named("javadoc") {
 		options.header = "<b>OSGi&reg; ${javadocTitle}</b><br/>${javadocTitleVersion}"
 		include javadocIncludes.text.tokenize(",")
 		linkProjects.each { linkProject ->
-			File linkJavadocVersion = linkProject.tasks.named("jar").flatMap({it.javadocVersion}).get().getAsFile()
+			File linkJavadocVersion = linkProject.tasks.named("jar").flatMap({it.jarVersion}).get().getAsFile()
 			File linkDestinationDir = linkProject.tasks.named("javadoc").map({it.destinationDir}).get()
 			options.linksOffline("../../${linkProject.getName()}/${linkJavadocVersion.text}", linkDestinationDir.absolutePath)
 		}
@@ -107,5 +106,5 @@ def javadoc = tasks.named("javadoc") {
 }
 
 tasks.named("release") {
-	dependsOn(javadoc)
+	inputs.files(javadoc).withPropertyName(javadoc.name)
 }

--- a/cnf/promise.bnd
+++ b/cnf/promise.bnd
@@ -1,6 +1,8 @@
 # bnd instructions for Promise projects
 
-# Uncomment the following line to build the non-snapshot version.
+# -snapshot unset (commented out) is a snapshot build. (e.g. 6.0.0-SNAPSHOT)
+# -snapshot set to a value (e.g. RC1) is a release build with the value as the Maven version qualifier. (e.g. 6.0.0-RC1)
+# -snapshot set to the empty string is a release build with no Maven version qualifier. (e.g. 6.0.0)
 #-snapshot:
 
 packaging: cmpn,promise

--- a/cnf/publish.bnd
+++ b/cnf/publish.bnd
@@ -1,0 +1,11 @@
+# Common configuration for publishing
+
+-baseline: *
+
+-maven-release: pom;path=JAR,javadoc;path="${target}/docs/javadoc",${if;${is;${env;GPG_PASSPHRASE;UNSET};UNSET};;sign\\;passphrase="${first;${env;GPG_PASSPHRASE};DEFAULT}"}
+
+# Release to publishrepo only if the version does not match the baseline version
+baseline_jars: ${split;\\n|\\r\\n|\\r;${cat;${build}/ext/baseline.mvn}}
+baseline_jar: ${filter;${baseline_jars};\\Q${-groupid}:${def;spec.package;${p}}:\\E.*}
+jar_version: ${if;${isfile;${target}/version.txt};${versionmask;===;${version_cleanup;${cat;${target}/version.txt}}}}
+-releaserepo.publish: ${if;${endswith;${baseline_jar};:${jar_version}};;${publishrepo}}

--- a/osgi.annotation/bnd.bnd
+++ b/osgi.annotation/bnd.bnd
@@ -1,13 +1,10 @@
 # Set javac settings from JDT prefs
--include : ${build}/eclipse/jdt.bnd, layout.bnd, ${build}/annotation.bnd
+-include : ${build}/eclipse/jdt.bnd, ${.}/layout.bnd, ${build}/annotation.bnd, ${build}/publish.bnd
+companion.code = true
 
 Bundle-Description: \
     OSGi Annotation Release ${versionmask;=;${build.version}}, \
     Annotations for use in compiling bundles
--maven-release: pom;path=JAR,javadoc;path="${target}/docs/javadoc",${def;mavensign}
-
--baseline: *
-companion.code = true
 
 Export-Package: ${osgi.annotation.packages}
 

--- a/osgi.cmpn/bnd.bnd
+++ b/osgi.cmpn/bnd.bnd
@@ -1,13 +1,10 @@
 # Set javac settings from JDT prefs
--include : ${build}/eclipse/jdt.bnd, layout.bnd, ${build}/cmpn.bnd
+-include : ${build}/eclipse/jdt.bnd, ${.}/layout.bnd, ${build}/cmpn.bnd, ${build}/publish.bnd
+companion.code = true
 
 Bundle-Description: \
 	OSGi Compendium Release ${versionmask;=;${build.version}}, \
 	Interfaces and Classes for use in compiling bundles
--maven-release: pom;path=JAR,javadoc;path="${target}/docs/javadoc",${def;mavensign}
-
--baseline: *
-companion.code = true
 
 Import-Package: *; resolution:=optional
 

--- a/osgi.cmpn/bnd.bnd
+++ b/osgi.cmpn/bnd.bnd
@@ -2,6 +2,9 @@
 -include : ${build}/eclipse/jdt.bnd, ${.}/layout.bnd, ${build}/cmpn.bnd, ${build}/publish.bnd
 companion.code = true
 
+# Don't publish osgi.cmpn
+publishrepo:
+
 Bundle-Description: \
 	OSGi Compendium Release ${versionmask;=;${build.version}}, \
 	Interfaces and Classes for use in compiling bundles

--- a/osgi.companion/bnd.bnd
+++ b/osgi.companion/bnd.bnd
@@ -1,4 +1,4 @@
--include = ${build}/eclipse/jdt.bnd, layout.bnd
+-include = ${build}/eclipse/jdt.bnd, ${.}/layout.bnd
 
 -nobundles = true
 

--- a/osgi.core/bnd.bnd
+++ b/osgi.core/bnd.bnd
@@ -1,14 +1,11 @@
 # Set javac settings from JDT prefs
--include : ${build}/eclipse/jdt.bnd, layout.bnd, ${build}/core.bnd
+-include : ${build}/eclipse/jdt.bnd, ${.}/layout.bnd, ${build}/core.bnd, ${build}/publish.bnd
+companion.code = true
 
 Automatic-Module-Name: ${bsn}
 Bundle-Description: \
 	OSGi Core Release ${versionmask;=;${build.version}}, \
 	Interfaces and Classes for use in compiling bundles
--maven-release: pom;path=JAR,javadoc;path="${target}/docs/javadoc",${def;mavensign}
-
--baseline: *
-companion.code = true
 
 Import-Package: *; resolution:=optional
 

--- a/osgi.impl/bnd.bnd
+++ b/osgi.impl/bnd.bnd
@@ -1,4 +1,4 @@
--include            : ${build}/eclipse/jdt.bnd, layout.bnd
+-include            : ${build}/eclipse/jdt.bnd, ${.}/layout.bnd
 -dependson          : osgi.companion, ${build.impls}
 -resourceonly       : true
 

--- a/osgi.promise/bnd.bnd
+++ b/osgi.promise/bnd.bnd
@@ -1,14 +1,11 @@
 # Set javac settings from JDT prefs
--include : ${build}/eclipse/jdt.bnd, layout.bnd, ${build}/promise.bnd
+-include : ${build}/eclipse/jdt.bnd, ${.}/layout.bnd, ${build}/promise.bnd, ${build}/publish.bnd
+companion.code = true
 
 Automatic-Module-Name: ${bsn}
 Bundle-Description: \
     OSGi Promise API Release ${versionmask;=;${build.version}} \
     for use inside and outside of OSGi environments
--maven-release: pom;path=JAR,javadoc;path="${target}/docs/javadoc",${def;mavensign}
-
--baseline: *
-companion.code = true
 
 Export-Package: ${osgi.promise.packages}
 

--- a/osgi.tck/bnd.bnd
+++ b/osgi.tck/bnd.bnd
@@ -1,4 +1,4 @@
--include            : ${build}/eclipse/jdt.bnd, layout.bnd
+-include            : ${build}/eclipse/jdt.bnd, ${.}/layout.bnd
 -dependson          : osgi.companion, ${build.tests}
 -resourceonly       : true
 


### PR DESCRIPTION
When the version of the built jar matches the version of the baseline
jar, then we do not publish as the version is already published in
Maven Central.