### PR TITLE
Build updates

### DIFF
--- a/cnf/annotation.bnd
+++ b/cnf/annotation.bnd
@@ -1,8 +1,3 @@
-# bnd instructions for Annotation projects
-
-# -snapshot unset (commented out) is a snapshot build. (e.g. 6.0.0-SNAPSHOT)
-# -snapshot set to a value (e.g. RC1) is a release build with the value as the Maven version qualifier. (e.g. 6.0.0-RC1)
-# -snapshot set to the empty string is a release build with no Maven version qualifier. (e.g. 6.0.0)
-#-snapshot:
+# Common configuration for Annotation projects
 
 packaging: annotation

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -72,13 +72,16 @@ build.version				= ${build.versionmask;${osgi.version}}.${project.build}
 
 osgi.annotation.buildpath = osgi.annotation;maven-scope=compile;version=snapshot
 
-# Documentation
+# -snapshot unset (commented out) is a snapshot build. (e.g. 6.0.0-SNAPSHOT)
+# -snapshot set to a value (e.g. RC1) is a release build with the value as the Maven version qualifier. (e.g. 6.0.0-RC1)
+# -snapshot set to the empty string is a release build with no Maven version qualifier. (e.g. 6.0.0)
+#-snapshot:
+
 -groupid: org.osgi
 -pom: version=${if;${def;-snapshot};${versionmask;===;${@version}}-${-snapshot};${versionmask;===s;${@version}}}
 Bundle-Name: ${-groupid}:${bsn}
 Bundle-Copyright: ${copyright}
 Bundle-Vendor:    Eclipse Foundation
-# To build the non-snapshot version, see the packaging bnd files for -snapshot.
 Bundle-Version:   ${build.version}-SNAPSHOT
 Bundle-DocURL:    https://docs.osgi.org/
 Git-Descriptor:   ${system-allow-fail;git describe --dirty --always --abbrev=9}

--- a/cnf/cmpn.bnd
+++ b/cnf/cmpn.bnd
@@ -1,8 +1,3 @@
-# bnd instructions for Compendium projects
-
-# -snapshot unset (commented out) is a snapshot build. (e.g. 6.0.0-SNAPSHOT)
-# -snapshot set to a value (e.g. RC1) is a release build with the value as the Maven version qualifier. (e.g. 6.0.0-RC1)
-# -snapshot set to the empty string is a release build with no Maven version qualifier. (e.g. 6.0.0)
-#-snapshot:
+# Common configuration for Compendium projects
 
 packaging: cmpn

--- a/cnf/core.bnd
+++ b/cnf/core.bnd
@@ -1,8 +1,3 @@
-# bnd instructions for Core projects
-
-# -snapshot unset (commented out) is a snapshot build. (e.g. 6.0.0-SNAPSHOT)
-# -snapshot set to a value (e.g. RC1) is a release build with the value as the Maven version qualifier. (e.g. 6.0.0-RC1)
-# -snapshot set to the empty string is a release build with no Maven version qualifier. (e.g. 6.0.0)
-#-snapshot:
+# Common configuration for Core projects
 
 packaging: core

--- a/cnf/ext/repositories.bnd
+++ b/cnf/ext/repositories.bnd
@@ -34,12 +34,12 @@
 
 -plugin.repositories.nexus: \
     aQute.bnd.repository.maven.provider.MavenBndRepository; \
-        name='OSGiNexus'; \
-        snapshotUrl="https://oss.sonatype.org/content/repositories/snapshots/"; \
-        releaseUrl="https://oss.sonatype.org/service/local/staging/deploy/maven2/"; \
+        name='OSSRH'; \
+        snapshotUrl="${env;OSSRH_SNAPSHOT;https://oss.sonatype.org/content/repositories/snapshots/}"; \
+        releaseUrl="${env;OSSRH_RELEASE;https://oss.sonatype.org/service/local/staging/deploy/maven2/}"; \
         noupdateOnRelease=true
 
-publishrepo: ${if;${env;OSSRH_USERNAME};OSGiNexus}
+publishrepo: ${if;${env;OSSRH_USERNAME};OSSRH}
 -connection-settings.publish: ${if;${publishrepo};${.}/ossrh-settings.xml}
 
 -buildrepo: Local

--- a/cnf/promise.bnd
+++ b/cnf/promise.bnd
@@ -1,8 +1,3 @@
-# bnd instructions for Promise projects
-
-# -snapshot unset (commented out) is a snapshot build. (e.g. 6.0.0-SNAPSHOT)
-# -snapshot set to a value (e.g. RC1) is a release build with the value as the Maven version qualifier. (e.g. 6.0.0-RC1)
-# -snapshot set to the empty string is a release build with no Maven version qualifier. (e.g. 6.0.0)
-#-snapshot:
+# Common configuration for Promise projects
 
 packaging: cmpn,promise


### PR DESCRIPTION
Since we now only publish when artifact versions change, we can pull -snapshot back into cnf.

Almost failed to properly publish org.osgi.util.tracker micro change since it is part of the Core group.