### PR TITLE
ci: Add step for release to create a staging repository id

### DIFF
--- a/.github/scripts/staging.sh
+++ b/.github/scripts/staging.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#*******************************************************************************
+# Copyright (c) Contributors to the Eclipse Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 
+#*******************************************************************************
+set -ev
+
+OSSRH_STAGINGPROFILEURI=$(curl --silent --request GET -u "$OSSRH_USERNAME:$OSSRH_PASSWORD" --header 'Accept: application/json' --header 'Content-Type: application/json' --url https://oss.sonatype.org/service/local/staging/profiles | jq --raw-output '.data[] | select(.name == "org.osgi") | .resourceURI')
+OSSRH_STAGINGREPOSITORYID=$(curl --silent --request POST -u "$OSSRH_USERNAME:$OSSRH_PASSWORD" --header 'Accept: application/json' --header 'Content-Type: application/json' --url $OSSRH_STAGINGPROFILEURI/start --data '{ "data": {"description": "OSGi Working Group"}}' | jq --raw-output '.data.stagedRepositoryId')
+echo "OSSRH_STAGINGREPOSITORYID=$OSSRH_STAGINGREPOSITORYID" >> $GITHUB_ENV
+echo "OSSRH_RELEASE=https://oss.sonatype.org/service/local/staging/deployByRepositoryId/$OSSRH_STAGINGREPOSITORYID" >> $GITHUB_ENV

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -83,6 +83,13 @@ jobs:
         path: |
           osgi.tck/generated/osgi.tck.*/
           !osgi.tck/generated/osgi.tck.*.jar
+    - name: Create Staging Repository
+      if: ${{ fromJSON(env.canonical) && (github.ref == 'refs/heads/release') }}
+      run: |
+        ./.github/scripts/staging.sh
+      env:
+        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
     - name: Release
       id: release
       if: ${{ fromJSON(env.canonical) }}
@@ -90,6 +97,7 @@ jobs:
         ./.github/scripts/publish.sh
       env:
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        OSSRH_RELEASE: ${{ env.OSSRH_RELEASE }}
         OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
     - name: Upload Generated Repo

--- a/cnf/ext/repositories.bnd
+++ b/cnf/ext/repositories.bnd
@@ -32,11 +32,11 @@
         index=${.}/baseline.mvn;\
         readOnly=true
 
--plugin.repositories.nexus: \
+-plugin.repositories.ossrh: \
     aQute.bnd.repository.maven.provider.MavenBndRepository; \
         name='OSSRH'; \
-        snapshotUrl="${env;OSSRH_SNAPSHOT;https://oss.sonatype.org/content/repositories/snapshots/}"; \
-        releaseUrl="${env;OSSRH_RELEASE;https://oss.sonatype.org/service/local/staging/deploy/maven2/}"; \
+        snapshotUrl="${first;${env;OSSRH_SNAPSHOT};https://oss.sonatype.org/content/repositories/snapshots/}"; \
+        releaseUrl="${first;${env;OSSRH_RELEASE};https://oss.sonatype.org/service/local/staging/deploy/maven2/}"; \
         noupdateOnRelease=true
 
 publishrepo: ${if;${env;OSSRH_USERNAME};OSSRH}


### PR DESCRIPTION
We use a curl request to obtain the staging profile URI for the
org.osgi group id. And then we make a curl request to start a
staging repository. The URL to the created staging repository
is place in the GitHub actions env context for access by later
steps in the job.

