### PR TITLE
service: Improve description of natural order and ranking order

### DIFF
--- a/org.osgi.framework/src/org/osgi/framework/BundleContext.java
+++ b/org.osgi.framework/src/org/osgi/framework/BundleContext.java
@@ -530,12 +530,10 @@ public interface BundleContext extends BundleReference {
 	 * expression, and the packages for the class names under which the services
 	 * were registered match the context bundle's packages as defined in
 	 * {@link ServiceReference#isAssignableTo(Bundle, String)}.
-	 * 
 	 * <p>
 	 * The list is valid at the time of the call to this method. However since
 	 * the Framework is a very dynamic environment, services can be modified or
 	 * unregistered at any time.
-	 * 
 	 * <p>
 	 * The specified {@code filter} expression is used to select the registered
 	 * services whose service properties contain keys and values which satisfy
@@ -545,7 +543,6 @@ public interface BundleContext extends BundleReference {
 	 * {@code filter} expression cannot be parsed, an
 	 * {@link InvalidSyntaxException} will be thrown with a human readable
 	 * message where the filter became unparsable.
-	 * 
 	 * <p>
 	 * The result is an array of {@code ServiceReference} objects for all
 	 * services that meet all of the following conditions:
@@ -567,12 +564,14 @@ public interface BundleContext extends BundleReference {
 	 * </ul>
 	 * 
 	 * @param clazz The class name with which the service was registered or
-	 *        {@code null} for all services.
+	 *            {@code null} for all services.
 	 * @param filter The filter expression or {@code null} for all services.
 	 * @return An array of {@code ServiceReference} objects or {@code null} if
-	 *         no services are registered which satisfy the search.
+	 *         no services are registered which satisfy the search. There is no
+	 *         guarantee that the {@code ServiceReference} objects in the array
+	 *         will be in any specific order.
 	 * @throws InvalidSyntaxException If the specified {@code filter} contains
-	 *         an invalid filter expression that cannot be parsed.
+	 *             an invalid filter expression that cannot be parsed.
 	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 */
 	ServiceReference<?>[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException;
@@ -582,12 +581,10 @@ public interface BundleContext extends BundleReference {
 	 * of {@code ServiceReference} objects contains services that were
 	 * registered under the specified class and match the specified filter
 	 * expression.
-	 * 
 	 * <p>
 	 * The list is valid at the time of the call to this method. However since
 	 * the Framework is a very dynamic environment, services can be modified or
 	 * unregistered at any time.
-	 * 
 	 * <p>
 	 * The specified {@code filter} expression is used to select the registered
 	 * services whose service properties contain keys and values which satisfy
@@ -597,7 +594,6 @@ public interface BundleContext extends BundleReference {
 	 * {@code filter} expression cannot be parsed, an
 	 * {@link InvalidSyntaxException} will be thrown with a human readable
 	 * message where the filter became unparsable.
-	 * 
 	 * <p>
 	 * The result is an array of {@code ServiceReference} objects for all
 	 * services that meet all of the following conditions:
@@ -615,12 +611,14 @@ public interface BundleContext extends BundleReference {
 	 * </ul>
 	 * 
 	 * @param clazz The class name with which the service was registered or
-	 *        {@code null} for all services.
+	 *            {@code null} for all services.
 	 * @param filter The filter expression or {@code null} for all services.
 	 * @return An array of {@code ServiceReference} objects or {@code null} if
-	 *         no services are registered which satisfy the search.
+	 *         no services are registered which satisfy the search. There is no
+	 *         guarantee that the {@code ServiceReference} objects in the array
+	 *         will be in any specific order.
 	 * @throws InvalidSyntaxException If the specified {@code filter} contains
-	 *         an invalid filter expression that cannot be parsed.
+	 *             an invalid filter expression that cannot be parsed.
 	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 * @since 1.3
 	 */
@@ -629,12 +627,10 @@ public interface BundleContext extends BundleReference {
 	/**
 	 * Returns a {@code ServiceReference} object for a service that implements
 	 * and was registered under the specified class.
-	 * 
 	 * <p>
 	 * The returned {@code ServiceReference} object is valid at the time of the
 	 * call to this method. However as the Framework is a very dynamic
 	 * environment, services can be modified or unregistered at any time.
-	 * 
 	 * <p>
 	 * This method is the same as calling
 	 * {@link #getServiceReferences(String, String)} with a {@code null} filter
@@ -642,14 +638,8 @@ public interface BundleContext extends BundleReference {
 	 * is provided as a convenience for when the caller is interested in any
 	 * service that implements the specified class.
 	 * <p>
-	 * If multiple such services exist, the service with the highest priority is
-	 * selected. This priority is defined as the service reference with the
-	 * highest ranking (as specified in its {@link Constants#SERVICE_RANKING}
-	 * property) is returned.
-	 * <p>
-	 * If there is a tie in ranking, the service with the lowest service id (as
-	 * specified in its {@link Constants#SERVICE_ID} property); that is, the
-	 * service that was registered first is returned.
+	 * If multiple such services exist, the service that is first in the
+	 * {@link ServiceReference#compareTo(Object) ranking order} is returned.
 	 * 
 	 * @param clazz The class name with which the service was registered.
 	 * @return A {@code ServiceReference} object, or {@code null} if no services
@@ -662,28 +652,22 @@ public interface BundleContext extends BundleReference {
 	/**
 	 * Returns a {@code ServiceReference} object for a service that implements
 	 * and was registered under the name of the specified class.
-	 * 
 	 * <p>
 	 * The returned {@code ServiceReference} object is valid at the time of the
 	 * call to this method. However as the Framework is a very dynamic
 	 * environment, services can be modified or unregistered at any time.
-	 * 
 	 * <p>
 	 * This method is the same as calling
 	 * {@link #getServiceReferences(Class, String)} with a {@code null} filter
 	 * expression. It is provided as a convenience for when the caller is
 	 * interested in any service that implements the specified class.
 	 * <p>
-	 * If multiple such services exist, the service with the highest ranking (as
-	 * specified in its {@link Constants#SERVICE_RANKING} property) is returned.
-	 * <p>
-	 * If there is a tie in ranking, the service with the lowest service id (as
-	 * specified in its {@link Constants#SERVICE_ID} property); that is, the
-	 * service that was registered first is returned.
+	 * If multiple such services exist, the service that is first in the
+	 * {@link ServiceReference#compareTo(Object) ranking order} is returned.
 	 * 
 	 * @param <S> Type of Service.
 	 * @param clazz The class under whose name the service was registered. Must
-	 *        not be {@code null}.
+	 *            not be {@code null}.
 	 * @return A {@code ServiceReference} object, or {@code null} if no services
 	 *         are registered which implement the specified class.
 	 * @throws IllegalStateException If this BundleContext is no longer valid.
@@ -699,12 +683,10 @@ public interface BundleContext extends BundleReference {
 	 * specified filter expression, and the packages for the class names under
 	 * which the services were registered match the context bundle's packages as
 	 * defined in {@link ServiceReference#isAssignableTo(Bundle, String)}.
-	 * 
 	 * <p>
 	 * The collection is valid at the time of the call to this method. However
 	 * since the Framework is a very dynamic environment, services can be
 	 * modified or unregistered at any time.
-	 * 
 	 * <p>
 	 * The specified {@code filter} expression is used to select the registered
 	 * services whose service properties contain keys and values which satisfy
@@ -714,7 +696,6 @@ public interface BundleContext extends BundleReference {
 	 * {@code filter} expression cannot be parsed, an
 	 * {@link InvalidSyntaxException} will be thrown with a human readable
 	 * message where the filter became unparsable.
-	 * 
 	 * <p>
 	 * The result is a collection of {@code ServiceReference} objects for all
 	 * services that meet all of the following conditions:
@@ -736,12 +717,14 @@ public interface BundleContext extends BundleReference {
 	 * 
 	 * @param <S> Type of Service
 	 * @param clazz The class under whose name the service was registered. Must
-	 *        not be {@code null}.
+	 *            not be {@code null}.
 	 * @param filter The filter expression or {@code null} for all services.
 	 * @return A collection of {@code ServiceReference} objects. May be empty if
-	 *         no services are registered which satisfy the search.
+	 *         no services are registered which satisfy the search. There is no
+	 *         guarantee that the {@code ServiceReference} objects in the
+	 *         collection will be in any specific order.
 	 * @throws InvalidSyntaxException If the specified {@code filter} contains
-	 *         an invalid filter expression that cannot be parsed.
+	 *             an invalid filter expression that cannot be parsed.
 	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 * @since 1.6
 	 */

--- a/org.osgi.framework/src/org/osgi/framework/ServiceReference.java
+++ b/org.osgi.framework/src/org/osgi/framework/ServiceReference.java
@@ -171,7 +171,8 @@ public interface ServiceReference<S>
 	/**
 	 * Compares this {@code ServiceReference} with the specified
 	 * {@code ServiceReference} for order.
-	 * 
+	 * <p>
+	 * <b>Natural Order</b>
 	 * <p>
 	 * If this {@code ServiceReference} and the specified
 	 * {@code ServiceReference} have the same {@link Constants#SERVICE_ID
@@ -184,15 +185,31 @@ public interface ServiceReference<S>
 	 * {@code ServiceReference} is less than the specified
 	 * {@code ServiceReference} if it has a higher {@link Constants#SERVICE_ID
 	 * service id} and greater if it has a lower service id.
+	 * <p>
+	 * Sorting a collection of {@code ServiceReference} objects with natural
+	 * order will result in the first element having the lowest
+	 * {@link Constants#SERVICE_RANKING service ranking} and the last element
+	 * having the highest {@link Constants#SERVICE_RANKING service ranking}.
+	 * <p>
+	 * <b>Ranking Order</b>
+	 * <p>
+	 * <em>Ranking order</em>, as defined in the Core Specification, is the
+	 * reverse of natural order.
+	 * <p>
+	 * Sorting a collection of {@code ServiceReference} objects with ranking
+	 * order will result in the first element having the highest
+	 * {@link Constants#SERVICE_RANKING service ranking} and the last element
+	 * having the lowest {@link Constants#SERVICE_RANKING service ranking}.
 	 * 
 	 * @param reference The {@code ServiceReference} to be compared.
 	 * @return Returns a negative integer, zero, or a positive integer if this
 	 *         {@code ServiceReference} is less than, equal to, or greater than
 	 *         the specified {@code ServiceReference}.
 	 * @throws IllegalArgumentException If the specified
-	 *         {@code ServiceReference} was not created by the same framework
-	 *         instance as this {@code ServiceReference}.
+	 *             {@code ServiceReference} was not created by the same
+	 *             framework instance as this {@code ServiceReference}.
 	 * @since 1.4
+	 * @see "Core Specification, Service Ranking Order"
 	 */
 	@Override
 	public int compareTo(Object reference);

--- a/org.osgi.framework/src/org/osgi/framework/hooks/resolver/ResolverHook.java
+++ b/org.osgi.framework/src/org/osgi/framework/hooks/resolver/ResolverHook.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 
 import org.osgi.annotation.versioning.ConsumerType;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.namespace.BundleNamespace;
 import org.osgi.framework.namespace.IdentityNamespace;
 import org.osgi.framework.wiring.BundleCapability;
@@ -32,7 +33,6 @@ import org.osgi.framework.wiring.FrameworkWiring;
 /**
  * OSGi Framework Resolver Hook instances are obtained from the OSGi
  * {@link ResolverHookFactory Framework Resolver Hook Factory} service.
- * 
  * <p>
  * A Resolver Hook instance is called by the framework during a resolve process.
  * A resolver hook may influence the outcome of a resolve process by removing
@@ -41,7 +41,6 @@ import org.osgi.framework.wiring.FrameworkWiring;
  * supports all remove operations. Any other attempts to modify a shrinkable
  * collection will result in an {@code UnsupportedOperationException} being
  * thrown.
- * 
  * <p>
  * The following steps outline the way a framework uses the resolver hooks
  * during a resolve process.
@@ -60,7 +59,6 @@ import org.osgi.framework.wiring.FrameworkWiring;
  * {@link ResolverHookFactory#begin(Collection)} method to inform the hooks
  * about a resolve process beginning and to obtain a Resolver Hook instance that
  * will be used for the duration of the resolve process.</li>
- * 
  * <li>Determine the collection of unresolved bundle revisions that may be
  * considered for resolution during the current resolution process and place
  * each of the bundle revisions in a shrinkable collection {@code Resolvable}.
@@ -78,7 +76,8 @@ import org.osgi.framework.wiring.FrameworkWiring;
  * <li>Determine the collection of available capabilities that have a namespace
  * of {@link IdentityNamespace osgi.identity}, are singletons, and have the same
  * symbolic name as the singleton bundle revision {@code B} and place each of
- * the matching capabilities into a shrinkable collection {@code Collisions}.</li>
+ * the matching capabilities into a shrinkable collection
+ * {@code Collisions}.</li>
  * <li>Remove the {@link IdentityNamespace osgi.identity} capability provided by
  * bundle revision {@code B} from shrinkable collection {@code Collisions}. A
  * singleton bundle cannot collide with itself.</li>
@@ -118,11 +117,11 @@ import org.osgi.framework.wiring.FrameworkWiring;
  * <li>For each resolver hook call the {@link #end()} method to inform the hooks
  * about a resolve process ending.</li>
  * </ol>
- * In all cases, the order in which the resolver hooks are called is the reverse
- * compareTo ordering of their Service References. That is, the service with the
- * highest ranking number must be called first. In cases where a shrinkable
- * collection becomes empty the framework is required to call the remaining
- * registered hooks.
+ * In all cases, the resolver hooks are called in
+ * {@link ServiceReference#compareTo(Object) ranking order}. That is, the
+ * service with the highest ranking must be called first. In cases where a
+ * shrinkable collection becomes empty the framework is required to call the
+ * remaining registered hooks.
  * <p>
  * Resolver hooks are low level. Implementations of the resolver hook must be
  * careful not to create an unresolvable state which is very hard for a

--- a/org.osgi.framework/src/org/osgi/framework/hooks/resolver/package-info.java
+++ b/org.osgi.framework/src/org/osgi/framework/hooks/resolver/package-info.java
@@ -31,7 +31,7 @@
  * @author $Id$
  */
 
-@Version("1.0")
+@Version("1.0.1")
 package org.osgi.framework.hooks.resolver;
 
 import org.osgi.annotation.versioning.Version;

--- a/org.osgi.service.component/src/org/osgi/service/component/ComponentContext.java
+++ b/org.osgi.service.component/src/org/osgi/service/component/ComponentContext.java
@@ -49,22 +49,19 @@ public interface ComponentContext {
 
 	/**
 	 * Returns the service object for the specified reference name.
-	 * 
 	 * <p>
 	 * If the cardinality of the reference is {@code 0..n} or {@code 1..n} and
-	 * multiple services are bound to the reference, the service with the
-	 * highest ranking (as specified in its {@code Constants.SERVICE_RANKING}
-	 * property) is returned. If there is a tie in ranking, the service with the
-	 * lowest service id (as specified in its {@code Constants.SERVICE_ID}
-	 * property); that is, the service that was registered first is returned.
+	 * multiple services are bound to the reference, the service whose
+	 * {@code ServiceReference} is first in the ranking order is returned. See
+	 * {@code ServiceReference.compareTo(Object)}.
 	 * 
 	 * @param name The name of a reference as specified in a {@code reference}
-	 *        element in this component's description.
+	 *            element in this component's description.
 	 * @return A service object for the referenced service or {@code null} if
 	 *         the reference cardinality is {@code 0..1} or {@code 0..n} and no
 	 *         bound service is available.
 	 * @throws ComponentException If Service Component Runtime catches an
-	 *         exception while activating the bound service.
+	 *             exception while activating the bound service.
 	 */
 	public <S> S locateService(String name);
 
@@ -90,14 +87,16 @@ public interface ComponentContext {
 	 * Returns the service objects for the specified reference name.
 	 * 
 	 * @param name The name of a reference as specified in a {@code reference}
-	 *        element in this component's description.
+	 *            element in this component's description.
 	 * @return An array of service objects for the referenced service or
 	 *         {@code null} if the reference cardinality is {@code 0..1} or
 	 *         {@code 0..n} and no bound service is available. If the reference
 	 *         cardinality is {@code 0..1} or {@code 1..1} and a bound service
-	 *         is available, the array will have exactly one element.
+	 *         is available, the array will have exactly one element. There is
+	 *         no guarantee that the service objects in the array will be in any
+	 *         specific order.
 	 * @throws ComponentException If Service Component Runtime catches an
-	 *         exception while activating a bound service.
+	 *             exception while activating a bound service.
 	 */
 	public Object[] locateServices(String name);
 

--- a/org.osgi.service.component/src/org/osgi/service/component/annotations/CollectionType.java
+++ b/org.osgi.service.component/src/org/osgi/service/component/annotations/CollectionType.java
@@ -51,9 +51,9 @@ public enum CollectionType {
 	 * services.
 	 * <p>
 	 * The Maps must implement {@code Comparable} with the {@code compareTo}
-	 * method comparing service property maps using the same ordering as
-	 * {@code ServiceReference.compareTo} based upon service ranking and service
-	 * id.
+	 * method comparing service property maps using an ordering which is the
+	 * same as the natural ordering of {@code ServiceReference}s as specified in
+	 * {@code ServiceReference.compareTo}.
 	 */
 	PROPERTIES("properties"),
 
@@ -64,9 +64,10 @@ public enum CollectionType {
 	 * {@link #PROPERTIES}, and whose value is the bound service object.
 	 * <p>
 	 * The Map.Entries must implement {@code Comparable} with the
-	 * {@code compareTo} method comparing service property maps using the same
-	 * ordering as {@code ServiceReference.compareTo} based upon service ranking
-	 * and service id.
+	 * {@code compareTo} method comparing service property maps using an
+	 * ordering which is the same as the natural ordering of
+	 * {@code ServiceReference}s as specified in
+	 * {@code ServiceReference.compareTo}.
 	 */
 	TUPLE("tuple");
 

--- a/org.osgi.service.component/src/org/osgi/service/component/annotations/package-info.java
+++ b/org.osgi.service.component/src/org/osgi/service/component/annotations/package-info.java
@@ -25,7 +25,7 @@
  * @author $Id$
  */
 
-@Version(COMPONENT_SPECIFICATION_VERSION)
+@Version(COMPONENT_SPECIFICATION_VERSION + ".1")
 package org.osgi.service.component.annotations;
 
 import static org.osgi.service.component.ComponentConstants.COMPONENT_SPECIFICATION_VERSION;

--- a/org.osgi.service.component/src/org/osgi/service/component/package-info.java
+++ b/org.osgi.service.component/src/org/osgi/service/component/package-info.java
@@ -35,7 +35,7 @@
  * @author $Id$
  */
 
-@Version(COMPONENT_SPECIFICATION_VERSION)
+@Version(COMPONENT_SPECIFICATION_VERSION + ".1")
 package org.osgi.service.component;
 
 import static org.osgi.service.component.ComponentConstants.COMPONENT_SPECIFICATION_VERSION;

--- a/org.osgi.service.http.whiteboard/src/org/osgi/service/http/context/ServletContextHelper.java
+++ b/org.osgi.service.http.whiteboard/src/org/osgi/service/http/context/ServletContextHelper.java
@@ -34,30 +34,27 @@ import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 /**
  * Helper service for a servlet context used by a Http Whiteboard implementation
  * to serve HTTP requests.
- *
  * <p>
  * This service defines methods that the Http Whiteboard implementation may call
  * to get information for a request when dealing with whiteboard services.
- * 
  * <p>
  * Each {@code ServletContextHelper} is registered with a
  * {@link HttpWhiteboardConstants#HTTP_WHITEBOARD_CONTEXT_NAME
  * "osgi.http.whiteboard.context.name"} service property containing a name to
  * reference by servlets, servlet filters, resources, and listeners. If there is
  * more than one {@code ServletContextHelper} registered with the same context
- * name, the one with the highest service ranking is active, the others are
- * inactive.
- * 
+ * name, the one that is first in the
+ * {@link org.osgi.framework.ServiceReference#compareTo(Object) ranking order}
+ * is active, the others are inactive.
  * <p>
  * A context is registered with the
  * {@link HttpWhiteboardConstants#HTTP_WHITEBOARD_CONTEXT_PATH
  * "osgi.http.whiteboard.context.path"} service property to define a path under
  * which all services registered with this context are reachable. If there is
  * more than one {@code ServletContextHelper} registered with the same path,
- * each duplicate context path is searched by service ranking order according to
- * {@link org.osgi.framework.ServiceReference#compareTo(Object)} until a
- * matching servlet or resource is found.
- * 
+ * each duplicate context path is searched in
+ * {@link org.osgi.framework.ServiceReference#compareTo(Object) ranking order}
+ * until a matching servlet or resource is found.
  * <p>
  * Servlets, servlet filters, resources, and listeners services may be
  * associated with a {@code ServletContextHelper} service with the
@@ -66,23 +63,21 @@ import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
  * {@code ServletContextHelper} service does not exist or is currently not
  * active, the whiteboard services for that {@code ServletContextHelper} are not
  * active either.
- * 
  * <p>
  * If no {@code ServletContextHelper} service is associated, that is no
  * {@link HttpWhiteboardConstants#HTTP_WHITEBOARD_CONTEXT_SELECT
  * "osgi.http.whiteboard.context.select"} service property is configured for a
  * whiteboard service, a default {@code ServletContextHelper} is used.
- * 
  * <p>
  * Those whiteboard services that are associated with the same
  * {@code ServletContextHelper} object will share the same
  * {@code ServletContext} object.
- * 
  * <p>
  * The behavior of the methods on the default {@code ServletContextHelper} is
  * defined as follows:
  * <ul>
- * <li>{@link #getMimeType(String) getMimeType} - Always returns {@code null}.</li>
+ * <li>{@link #getMimeType(String) getMimeType} - Always returns
+ * {@code null}.</li>
  * <li>{@link #handleSecurity(HttpServletRequest, HttpServletResponse)
  * handleSecurity} - Always returns {@code true}.</li>
  * <li>{@link #getResource(String) getResource} - Assumes the named resource is
@@ -90,14 +85,16 @@ import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
  * calls the whiteboard service bundle's {@code Bundle.getEntry} method, and
  * returns the appropriate URL to access the resource. On a Java runtime
  * environment that supports permissions, the Http Whiteboard implementation
- * needs to be granted {@code org.osgi.framework.AdminPermission[*,RESOURCE]}.</li>
+ * needs to be granted
+ * {@code org.osgi.framework.AdminPermission[*,RESOURCE]}.</li>
  * <li>{@link #getResourcePaths(String) getResourcePaths} - Assumes that the
  * resources are in the bundle of the whiteboard service. This method calls
  * {@code Bundle.findEntries} method, and returns the found entries. On a Java
  * runtime environment that supports permissions, the Http Whiteboard
  * implementation needs to be granted
  * {@code org.osgi.framework.AdminPermission[*,RESOURCE]}.</li>
- * <li>{@link #getRealPath(String) getRealPath} - Always returns {@code null}.</li>
+ * <li>{@link #getRealPath(String) getRealPath} - Always returns
+ * {@code null}.</li>
  * </ul>
  * 
  * @ThreadSafe

--- a/org.osgi.service.http.whiteboard/src/org/osgi/service/http/context/package-info.java
+++ b/org.osgi.service.http.whiteboard/src/org/osgi/service/http/context/package-info.java
@@ -35,7 +35,7 @@
  * @author $Id$
  */
 
-@Version(HTTP_WHITEBOARD_SPECIFICATION_VERSION + ".0")
+@Version(HTTP_WHITEBOARD_SPECIFICATION_VERSION + ".1")
 package org.osgi.service.http.context;
 
 import static org.osgi.service.http.whiteboard.HttpWhiteboardConstants.HTTP_WHITEBOARD_SPECIFICATION_VERSION;

--- a/org.osgi.service.http.whiteboard/src/org/osgi/service/http/runtime/dto/DTOConstants.java
+++ b/org.osgi.service.http.whiteboard/src/org/osgi/service/http/runtime/dto/DTOConstants.java
@@ -45,8 +45,9 @@ public final class DTOConstants {
 	/**
 	 * Service is shadowed by another service.
 	 * <p>
-	 * For example, a service with the same service properties but a higher
-	 * service ranking.
+	 * For example, another service with the same service properties but having
+	 * a higher service ranking. See
+	 * {@link org.osgi.framework.ServiceReference#compareTo(Object)}.
 	 */
 	public static final int	FAILURE_REASON_SHADOWED_BY_OTHER_SERVICE	= 3;
 

--- a/org.osgi.service.http.whiteboard/src/org/osgi/service/http/runtime/dto/package-info.java
+++ b/org.osgi.service.http.whiteboard/src/org/osgi/service/http/runtime/dto/package-info.java
@@ -35,7 +35,7 @@
  * @author $Id$
  */
 
-@Version(HTTP_WHITEBOARD_SPECIFICATION_VERSION + ".0")
+@Version(HTTP_WHITEBOARD_SPECIFICATION_VERSION + ".1")
 package org.osgi.service.http.runtime.dto;
 
 import static org.osgi.service.http.whiteboard.HttpWhiteboardConstants.HTTP_WHITEBOARD_SPECIFICATION_VERSION;

--- a/org.osgi.service.http.whiteboard/src/org/osgi/service/http/whiteboard/Preprocessor.java
+++ b/org.osgi.service.http.whiteboard/src/org/osgi/service/http/whiteboard/Preprocessor.java
@@ -26,10 +26,9 @@ import org.osgi.annotation.versioning.ConsumerType;
  * Services registered as a {@code Preprocessor} using a whiteboard pattern are
  * executed for every request before the dispatching is performed.
  * <p>
- * If there are several services of this type, they are run in order of their
- * service ranking, the one with the highest ranking is used first. In the case
- * of a service ranking tie, the service with the lowest service id is processed
- * first.
+ * If there are several services of this type, they are run in
+ * {@link org.osgi.framework.ServiceReference#compareTo(Object) ranking order},
+ * the one with the highest ranking is used first.
  * <p>
  * The preprocessor is handled in the same way as filters. When a preprocessor
  * is put into service {@link Filter#init(javax.servlet.FilterConfig)} is

--- a/org.osgi.service.http.whiteboard/src/org/osgi/service/http/whiteboard/package-info.java
+++ b/org.osgi.service.http.whiteboard/src/org/osgi/service/http/whiteboard/package-info.java
@@ -35,7 +35,7 @@
  * @author $Id$
  */
 
-@Version(HTTP_WHITEBOARD_SPECIFICATION_VERSION + ".1")
+@Version(HTTP_WHITEBOARD_SPECIFICATION_VERSION + ".2")
 package org.osgi.service.http.whiteboard;
 
 import static org.osgi.service.http.whiteboard.HttpWhiteboardConstants.HTTP_WHITEBOARD_SPECIFICATION_VERSION;

--- a/org.osgi.service.jaxrs/src/org/osgi/service/jaxrs/runtime/dto/DTOConstants.java
+++ b/org.osgi.service.jaxrs/src/org/osgi/service/jaxrs/runtime/dto/DTOConstants.java
@@ -37,8 +37,9 @@ public final class DTOConstants {
 	/**
 	 * Service is shadowed by another service.
 	 * <p>
-	 * For example, a service with the same service properties but a higher
-	 * service ranking.
+	 * For example, another service with the same service properties but having
+	 * a higher service ranking. See
+	 * {@link org.osgi.framework.ServiceReference#compareTo(Object)}.
 	 */
 	public static final int	FAILURE_REASON_SHADOWED_BY_OTHER_SERVICE		= 1;
 

--- a/org.osgi.service.jaxrs/src/org/osgi/service/jaxrs/runtime/dto/package-info.java
+++ b/org.osgi.service.jaxrs/src/org/osgi/service/jaxrs/runtime/dto/package-info.java
@@ -35,7 +35,7 @@
  * @author $Id$
  */
 
-@Version(JAX_RS_WHITEBOARD_SPECIFICATION_VERSION + ".0")
+@Version(JAX_RS_WHITEBOARD_SPECIFICATION_VERSION + ".1")
 package org.osgi.service.jaxrs.runtime.dto;
 
 import static org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants.JAX_RS_WHITEBOARD_SPECIFICATION_VERSION;

--- a/org.osgi.service.jaxrs/src/org/osgi/service/jaxrs/whiteboard/package-info.java
+++ b/org.osgi.service.jaxrs/src/org/osgi/service/jaxrs/whiteboard/package-info.java
@@ -35,7 +35,7 @@
  * @author $Id$
  */
 
-@Version(JAX_RS_WHITEBOARD_SPECIFICATION_VERSION + ".1")
+@Version(JAX_RS_WHITEBOARD_SPECIFICATION_VERSION + ".2")
 package org.osgi.service.jaxrs.whiteboard;
 
 import static org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants.JAX_RS_WHITEBOARD_SPECIFICATION_VERSION;

--- a/org.osgi.util.tracker/src/org/osgi/util/tracker/ServiceTracker.java
+++ b/org.osgi.util.tracker/src/org/osgi/util/tracker/ServiceTracker.java
@@ -544,15 +544,11 @@ public class ServiceTracker<S, T> implements ServiceTrackerCustomizer<S, T> {
 	/**
 	 * Returns a {@code ServiceReference} for one of the services being tracked
 	 * by this {@code ServiceTracker}.
-	 * 
 	 * <p>
-	 * If multiple services are being tracked, the service with the highest
-	 * ranking (as specified in its {@code service.ranking} property) is
-	 * returned. If there is a tie in ranking, the service with the lowest
-	 * service id (as specified in its {@code service.id} property); that is,
-	 * the service that was registered first is returned. This is the same
-	 * algorithm used by {@code BundleContext.getServiceReference}.
-	 * 
+	 * If multiple services are being tracked, the service that is first in the
+	 * {@link ServiceReference#compareTo(Object) ranking order} is returned.
+	 * This is the same algorithm used by
+	 * {@code BundleContext.getServiceReference}.
 	 * <p>
 	 * This implementation calls {@link #getServiceReferences()} to get the list
 	 * of references for the tracked services.
@@ -775,9 +771,8 @@ public class ServiceTracker<S, T> implements ServiceTrackerCustomizer<S, T> {
 	/**
 	 * Return a {@code SortedMap} of the {@code ServiceReference}s and service
 	 * objects for all services being tracked by this {@code ServiceTracker}.
-	 * The map is sorted in reverse natural order of {@code ServiceReference}.
-	 * That is, the first entry is the service with the highest ranking and the
-	 * lowest service id.
+	 * The map is sorted in {@link ServiceReference#compareTo(Object) ranking
+	 * order}.
 	 * 
 	 * @return A {@code SortedMap} with the {@code ServiceReference}s and
 	 *         service objects for all services being tracked by this

--- a/org.osgi.util.tracker/src/org/osgi/util/tracker/package-info.java
+++ b/org.osgi.util.tracker/src/org/osgi/util/tracker/package-info.java
@@ -31,7 +31,7 @@
  * @author $Id$
  */
 
-@Version("1.5.4")
+@Version("1.5.5")
 package org.osgi.util.tracker;
 
 import org.osgi.annotation.versioning.Version;

--- a/osgi.specs/docbook/112/service.component.xml
+++ b/osgi.specs/docbook/112/service.component.xml
@@ -731,9 +731,9 @@
           <para><code>Map</code> - An unmodifiable Map containing the service
           properties of the bound service. This Map must additionally
           implement <code>Comparable</code> with the <code>compareTo</code>
-          method comparing service property maps using the same ordering as
-          <code>ServiceReference.compareTo</code> based upon service ranking
-          and service id.</para>
+          method comparing service property maps using an ordering which is
+          the same as the natural ordering of <code>ServiceReference</code>s
+          as specified in <code>ServiceReference.compareTo</code>.</para>
         </listitem>
       </itemizedlist>
 
@@ -943,9 +943,9 @@
           <para><code>Map</code> - An unmodifiable Map containing the service
           properties of the bound service. This Map must additionally
           implement <code>Comparable</code> with the <code>compareTo</code>
-          method comparing service property maps using the same ordering as
-          <code>ServiceReference.compareTo</code> based upon service ranking
-          and service id.</para>
+          method comparing service property maps using an ordering which is
+          the same as the natural ordering of <code>ServiceReference</code>s
+          as specified in <code>ServiceReference.compareTo</code>.</para>
         </listitem>
 
         <listitem>
@@ -954,9 +954,9 @@
           bound service, as above, and whose value is the bound service
           object. This Map.Entry must additionally implement
           <code>Comparable</code> with the <code>compareTo</code> method
-          comparing the service property map key using the same ordering as
-          <code>ServiceReference.compareTo</code> based upon service ranking
-          and service id.</para>
+          comparing the service property map key using an ordering which is
+          the same as the natural ordering of <code>ServiceReference</code>s
+          as specified in <code>ServiceReference.compareTo</code>.</para>
         </listitem>
 
         <listitem>
@@ -1265,11 +1265,8 @@ multiplicity ::= '1' | 'n'</programlisting>
       unsatisfied, the component configuration must be deactivated. If the
       reference has a unary cardinality and there is more than one target
       service for the reference, then the bound service must be the target
-      service with the highest service ranking as specified by the
-      <code>service.ranking</code> property. If there are multiple target
-      services with the same service ranking, then the bound service must be
-      the target service with the highest service ranking and the lowest
-      service id as specified by the <code>service.id</code> property.</para>
+      service whose <code>ServiceReference</code> is first in the ranking
+      order as specified in <code>ServiceReference.compareTo</code>.</para>
 
       <para>In the following example, a component wants to register a resource
       with all Http Services that are available. Such a scenario has the
@@ -1652,17 +1649,19 @@ public class HttpResourceImpl {
         if present, and the field must not be modified. Before the component
         instance is activated, SCR must set the field value with a new mutable
         collection that must contain the initial set of bound services sorted
-        using the same ordering as <code>ServiceReference.compareTo</code>
-        based upon service ranking and service id. The collection may be empty
+        using an ordering which is the same as the natural ordering of
+        <code>ServiceReference</code>s as specified in
+        <code>ServiceReference.compareTo</code>. The collection may be empty
         if the reference has optional cardinality and there are no bound
         services. If the reference is dynamic, when there is a change in the
         set of bound services or the service properties of a bound service are
         modified and the collection holds service properties, SCR must replace
         the field value with a new mutable collection that must contain the
-        updated set of bound services sorted using the same ordering as
-        <code>ServiceReference.compareTo</code> based upon service ranking and
-        service id. The new collection may be empty if the reference has
-        optional cardinality and there are no bound services.</para>
+        updated set of bound services sorted using an ordering which is the
+        same as the natural ordering of <code>ServiceReference</code>s as
+        specified in <code>ServiceReference.compareTo</code>. The new
+        collection may be empty if the reference has optional cardinality and
+        there are no bound services.</para>
       </section>
 
       <section>

--- a/osgi.specs/docbook/126/service.jndi.xml
+++ b/osgi.specs/docbook/126/service.jndi.xml
@@ -16,7 +16,6 @@
    
     SPDX-License-Identifier: Apache-2.0 
  -->
-
 <chapter label="126"
          revision="$Id$"
          version="5.0" xml:id="service.jndi"
@@ -248,9 +247,10 @@ javax.naming.directory</programlisting>
       registry. If such a service is found, then that service is used to
       create a new Context, which is subsequently returned. If no class name
       is specified, the service registry is searched for Initial Context
-      Factory services. These services are tried in ranking order to see if
-      they can create an appropriate Context, the first one that can create a
-      Context is then used.</para>
+      Factory services. These services are tried in ranking order, as
+      specified in <code>ServiceReference.compareTo</code>, to see if they can
+      create an appropriate Context, the first one that can create a Context
+      is then used.</para>
 
       <para>If no class name is specified, all Initial Context Factory Builder
       services are tried to see if they can create a Context, the first
@@ -693,11 +693,8 @@ javax.naming.directory</programlisting>
       <para>In the following sections the cases for presence or absence of the
       <code>java.naming.factory.initial</code> property are described. Several
       steps in these algorithm iterate over a set of available services. This
-      iteration must always take place in service <emphasis>ranking
-      order</emphasis>. Service ranking order follows the ordering of the
-      <code>service.ranking</code> service property, which is the highest
-      <code>service.ranking</code> value, or when equal, the lowest
-      <code>service.id</code> value.</para>
+      iteration must always take place in ranking order as specified in
+      <code>ServiceReference.compareTo</code>.</para>
 
       <para>Exception handling in the following steps is as follows:</para>
 
@@ -971,10 +968,11 @@ javax.naming.directory</programlisting>
       initial Context their applications receive.</para>
 
       <para>An Initial Context Factory Builder provider must register an
-      Initial Context Factory Builder service. The
-      <code>service.ranking</code> property defines the iteration ordering of
-      multiple Initial Context Factory Builder services. Implementations must
-      be careful to correctly provide defaults.</para>
+      Initial Context Factory Builder service. The iteration ordering of
+      multiple Initial Context Factory Builder services must always take place
+      in ranking order as specified in
+      <code>ServiceReference.compareTo</code>. Implementations must be careful
+      to correctly provide defaults.</para>
 
       <para>For example, a container could use a thread local variable to mark
       the stack for a specific application. The implementation of the Initial
@@ -1219,11 +1217,11 @@ jndi-name ::= &lt;any string&gt;</programlisting>
     incompatible with the class space of the owning bundle.</para>
 
     <para>The lookup for a URL with the <code>osgi:</code> scheme and
-    <code>service</code> path returns the service with highest
-    <code>service.ranking</code> and the lowest <code>service.id</code>. This
-    scheme only allows a single service to be found. Multiple services can be
-    obtained with the <code>osgi:</code> scheme and <code>servicelist</code>
-    path:</para>
+    <code>service</code> path returns the service whose
+    <code>ServiceReference</code> is first in ranking order as specified in
+    <code>ServiceReference.compareTo</code>. This scheme only allows a single
+    service to be found. Multiple services can be obtained with the
+    <code>osgi:</code> scheme and <code>servicelist</code> path:</para>
 
     <programlisting>servicelist ::= 'osgi:servicelist/' query?</programlisting>
 

--- a/osgi.specs/docbook/140/service.http.whiteboard.xml
+++ b/osgi.specs/docbook/140/service.http.whiteboard.xml
@@ -248,12 +248,11 @@
             <code>default</code>. To override the default, register a custom
             <code>ServletContextHelper</code> service with the name
             <code>default</code>. If multiple Servlet Context Helper services
-            are registered with the same name, the one with the highest
-            Service Ranking is used. In case of a tie, the service with the
-            lowest service ID wins. In other words, the normal OSGi service
-            ranking applies.</para> <para>Registrations with an invalid or
-            unspecified name are not used and reflected in the failure DTOs.
-            See <xref
+            are registered with the same name, the one that is first in
+            ranking order, as specified in
+            <code>ServiceReference.compareTo</code>, is
+            used.</para><para>Registrations with an invalid or unspecified
+            name are not used and reflected in the failure DTOs. See <xref
             linkend="org.osgi.service.http.whiteboard.HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME"
             xrefstyle="hyperlink"/>.</para></entry>
           </row>
@@ -303,10 +302,10 @@
         </listitem>
 
         <listitem>
-          <para>In the case of two Servlet Context Helpers with the same path,
-          the service with the highest ranking is searched first for a match.
-          In the case of a tie, the lowest service ID is searched
-          first.</para>
+          <para>In the case of multiple Servlet Context Helper services with
+          the same path, the services are searched in ranking order, as
+          specified in <code>ServiceReference.compareTo</code>, for a
+          match.</para>
         </listitem>
       </orderedlist></para>
 
@@ -324,7 +323,7 @@ osgi.http.whiteboard.context.path = /foo/bar</programlisting> Then a request
           <para><code>/foo</code> context looking for a pattern to match
           <code>/bar/someServlet</code></para>
         </listitem>
-      </orderedlist> Note that whole path segments must match. Therefore the
+      </orderedlist>Note that whole path segments must match. Therefore the
     following request can only be handled by the Servlet Context Helper
     registered under the /foo path:
     <code>http://localhost/foo/bars/someOtherServlet</code>.</para>
@@ -335,7 +334,7 @@ osgi.http.whiteboard.context.path = /foo/bar</programlisting> Then a request
     linkend="service.http.whiteboard.common.properties"/>.</para>
 
     <para>If a Servlet Context Helper can not be used, for example because it
-    is shadowed by another Servlet Context Helper service with the same name,
+    is shadowed by another Servlet Context Helper service with the same name
     but with a higher ranking, this is reflected in the <xref
     linkend="org.osgi.service.http.runtime.dto.FailedServletContextDTO"
     xrefstyle="hyperlink"/>. Similarly, if an alternative <code>default</code>
@@ -700,8 +699,8 @@ public class CDNServletContextHelper extends ServletContextHelper {
               <code>osgi.http.whiteboard.servlet.name</code> property, if
               associated with this Servlet Context Helper. If multiple
               servlets have the same name and are associated with this Servlet
-              Context Helper then the highest ranked servlet is used. In the
-              case of a tie, the one with the lowest service ID is
+              Context Helper, then the servlet that is first in ranking order,
+              as specified in <code>ServiceReference.compareTo</code>, is
               used.</para></entry>
             </row>
 
@@ -1102,11 +1101,12 @@ public class CDNServletContextHelper extends ServletContextHelper {
 
     <para><code>Servlet</code> and resource service registrations associated
     with a single Servlet Context share the same namespace. In case of
-    identical registration patterns, service ranking rules are used to select
-    the service handling a request. That is, Whiteboard servlets that have
-    patterns shadowed by other Whiteboard services associated with the
-    <emphasis>same</emphasis> Servlet Context are represented in the failure
-    DTOs.</para>
+    identical registration patterns, the service that is first in ranking
+    order, as specified in <code>ServiceReference.compareTo</code>, is
+    selected as the service handling a request. That is, Whiteboard servlets
+    that have patterns shadowed by other Whiteboard services associated with
+    the <emphasis>same</emphasis> Servlet Context are represented in the
+    failure DTOs.</para>
 
     <para>The above rules can cause servlets that are already bound becoming
     unbound if a better match arrives. This ensures a predictable end result
@@ -1493,7 +1493,8 @@ public class MyErrorServlet extends HttpServlet {
       <para>The example servlet is invoked in case of a <code>500</code> error
       code, or if an <code>IOException</code> (or subclass) occurs. If there
       is more than one error page registered for the same exception or error
-      code, service ranking rules are used to select the handling
+      code, the service that is first in ranking order, as specified in
+      <code>ServiceReference.compareTo</code>, is selected as the handling
       servlet.</para>
     </section>
 
@@ -1727,13 +1728,12 @@ public class AsyncServlet extends HttpServlet {
     services.</para>
 
     <para>Multiple servlet filters can process the same servlet
-    request/response. If more than one <code>Filter</code> matches, the order
-    in which they are processed is governed by their service ranking. The
-    servlet filter with the highest ranking is processed first in the filter
-    chain, while the servlet filter with the lowest ranking is processed last,
-    before the <code>Servlet.service</code> method is called. In the case of a
-    service ranking tie, the servlet filter with the lowest
-    <code>service.id</code> is processed first. After the servlet completes
+    request/response. If more than one <code>Filter</code> matches, they are
+    processed in ranking order, as specified in
+    <code>ServiceReference.compareTo</code>. The servlet filter with the
+    highest ranking is processed first in the filter chain, while the servlet
+    filter with the lowest ranking is processed last, before the
+    <code>Servlet.service</code> method is called. After the servlet completes
     its <code>service</code> method the filter chain is unwound in reverse
     order.</para>
 
@@ -2064,8 +2064,8 @@ public class SomeResourceService {}</programlisting>
     Helper.</para>
 
     <para>Multiple listeners of the same type registered with a given Servlet
-    Context Helper are invoked in sequence, service ranking rules are used to
-    determine the order.</para>
+    Context Helper are invoked in ranking order, as specified in
+    <code>ServiceReference.compareTo</code>.</para>
 
     <table pgwide="1">
       <title>Service properties for listener services.</title>

--- a/osgi.specs/docbook/151/service.jaxrs.xml
+++ b/osgi.specs/docbook/151/service.jaxrs.xml
@@ -16,7 +16,6 @@
    
     SPDX-License-Identifier: Apache-2.0 
  -->
-
 <chapter label="151"
          revision="$Id$"
          version="5.0" xml:id="service.jaxrs"
@@ -443,7 +442,8 @@ public String interrogateSession(@PathParam("name") String name,
             is registered with an illegal name then it is not bound and this
             is reflected in the failure DTOs. If two JAX-RS services are
             registered with the same name (even if they are advertised as
-            different types) then only the higher ranked service is bound and
+            different types) then only the first service in ranking order, as
+            specified in <code>ServiceReference.compareTo</code>, is bound and
             the lower ranked service(s) are reflected in the failure DTOs. See
             <xref
             linkend="org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants.JAX_RS_NAME"
@@ -605,14 +605,15 @@ public class Foo {
         <para>When clashes occur in the JAX-RS whiteboard then resources
         supplied using the service whiteboard must be preferred to static
         resources contained in the application. If two or more whiteboard
-        resources exist then they must be ordered using their service ranking.
-        Unlike for other services in the JAX-RS whiteboard, whiteboard
-        resource services must not be ordered using their natural ordering.
-        Whiteboard resource services with the same ranking must be considered
-        equal, following the normal resource method selection rules defined in
-        the JAX-RS specification. As per the core specification, whiteboard
-        services with no <code>service.ranking</code> property must be treated
-        as having a ranking of <code>0</code>.</para>
+        resources exist then they must be ordered using ranking order, as
+        specified in <code>ServiceReference.compareTo</code>. Unlike for other
+        services in the JAX-RS whiteboard, whiteboard resource services must
+        not be ordered using their natural ordering. Whiteboard resource
+        services with the same ranking must be considered equal, following the
+        normal resource method selection rules defined in the JAX-RS
+        specification. As per the Core specification, whiteboard services with
+        no <code>service.ranking</code> property must be treated as having a
+        ranking of <code>0</code>.</para>
       </section>
     </section>
 
@@ -719,17 +720,17 @@ public class Foo {
     }
 }</programlisting>
 
-        <para>Single valued asynchronous results can also be provided by returning 
-        a suitable type from the resource method. This can be a 
+        <para>Single valued asynchronous results can also be provided by
+        returning a suitable type from the resource method. This can be a
         <code>CompletionStage</code> as described in the JAX-RS specification,
-        or an OSGi <code>Promise</code> type. In this case the response from the 
-        resource method will be sent once the returned type has completed, either 
-        successfully or by failing.</para>
-        
-        <para>The following example demonstrates the use of an
-        asynchronous return value:</para>
-        
-<programlisting>@Component(service = MyResource.class,
+        or an OSGi <code>Promise</code> type. In this case the response from
+        the resource method will be sent once the returned type has completed,
+        either successfully or by failing.</para>
+
+        <para>The following example demonstrates the use of an asynchronous
+        return value:</para>
+
+        <programlisting>@Component(service = MyResource.class,
       scope = ServiceScope.PROTOTYPE)
  @JaxrsResource     
  public class MyResource {
@@ -1015,8 +1016,9 @@ public class FizzResource {
       ordered according to their <code>javax.annotation.Priority</code>. If
       two extensions of the same type have the same priority then the
       whiteboard implementation must break the tie by ordering the extensions
-      according to the natural ordering of their service references, with
-      static extensions being ranked below all whiteboard services.</para>
+      according to the natural ordering of their service references, as
+      specified in <code>ServiceReference.compareTo</code>, with static
+      extensions being ranked below all whiteboard services.</para>
 
       <para>The extension processing flow is as follows:</para>
 
@@ -1326,11 +1328,12 @@ public class JsonProvider implements MessageBodyReader,
 
       <para>The base URI for each application within the whiteboard must be
       unique. If two or more applications targeting the same whiteboard are
-      registered with the same base URI then only the highest ranked service
-      will be made available. All other application services with that URI
-      will have a failure DTO created for them. The same rules also apply to
-      the <code>osgi.jaxrs.name</code> property, with the highest ranked
-      service shadowing other applications with the same name.</para>
+      registered with the same base URI then only the first in ranking order,
+      as specified in <code>ServiceReference.compareTo</code>, will be made
+      available. All other application services with that URI will have a
+      failure DTO created for them. The same rules also apply to the
+      <code>osgi.jaxrs.name</code> property, with the highest ranked service
+      shadowing other applications with the same name.</para>
 
       <para>The default application is implicitly created by the whiteboard
       and has the name <code>.default</code>. The default application has a

--- a/osgi.specs/docbook/core/005/framework.service.xml
+++ b/osgi.specs/docbook/core/005/framework.service.xml
@@ -678,8 +678,9 @@
       ranking order is in descending <code>service.ranking</code> numeric
       order where ties give a preference to the earlier registrant.</para>
 
-      <para>The ranking order is the reverse of the natural ordering of a
-      <code>ServiceReference</code> object.</para>
+      <para>The ranking order is the reverse of the <link
+      linkend="org.osgi.framework.ServiceReference.compareTo-Object-">natural
+      ordering</link> of a <code>ServiceReference</code> object.</para>
 
       <para>The purpose of the ranking order is to allow:</para>
 
@@ -735,14 +736,10 @@
           <code>ServiceReference</code> object to a service object that
           implements, and was registered under, the name of the specified
           service interface. If multiple such service objects exist, a
-          <code>ServiceReference</code> object to the service object with the
-          highest <xref linkend="org.osgi.framework.Constants.SERVICE_RANKING"
-          xrefstyle="hyperlink"/> is returned. If there is a tie in ranking, a
-          <code>ServiceReference</code> object to the service object with the
-          lowest <xref linkend="org.osgi.framework.Constants.SERVICE_ID"
-          xrefstyle="hyperlink"/> (the service object that was registered
-          first) is returned. If no matching service objects are registered
-          then <code>null</code> must be returned.</para>
+          <code>ServiceReference</code> object to the service that is first in
+          <link linkend="framework.service.servicerankingorder">ranking
+          order</link> is returned. If no matching service objects are
+          registered then <code>null</code> must be returned.</para>
         </listitem>
 
         <listitem>
@@ -772,7 +769,9 @@
           xrefstyle="hyperlink"/> method and an empty collection must be
           returned by the <xref
           linkend="org.osgi.framework.BundleContext.getServiceReferences-Class-String-"
-          xrefstyle="hyperlink"/> method.</para>
+          xrefstyle="hyperlink"/> method. There is no guarantee that the
+          <code>ServiceReference</code> objects in the array or collection
+          will be in any specific order.</para>
         </listitem>
       </itemizedlist>
 

--- a/osgi.specs/docbook/core/052/service.url.xml
+++ b/osgi.specs/docbook/core/052/service.url.xml
@@ -16,7 +16,6 @@
    
     SPDX-License-Identifier: Apache-2.0 
  -->
-
 <chapter label="52" revision="$Id$"
          version="5.0" xml:id="service.url"
          xmlns="http://docbook.org/ns/docbook"
@@ -353,13 +352,11 @@
       <para>Once the proxy is created, it must track the service registry for
       registrations and unregistrations of services matching its associated
       scheme. The proxy must be associated with the service that matches the
-      scheme and has the highest value for the
-      <code>org.osgi.framework.Constants.SERVICE_RANKING</code> service
-      registration property (see <xref
-      linkend="framework.service.serviceproperties"/> ) at any moment in time.
-      If a proxy is associated with a URL Stream Handler Service, it must
-      change the associated handler to a newly registered service when that
-      service has a higher value for the ranking property.</para>
+      scheme and has the highest ranking (first in <link
+      linkend="framework.service.servicerankingorder">ranking order</link>) at
+      any moment in time. If a proxy is associated with a URL Stream Handler
+      Service, it must change the associated handler to a newly registered
+      service when that service has a higher ranking.</para>
 
       <para>The proxy object must forward all method requests to the
       associated URL Stream Handler Service until this service object becomes
@@ -538,8 +535,8 @@ com.acme.url.application.zip</programlisting></para>
       implementation classes, the <code>AbstractURLStreamHandlerService</code>
       has been provided. Apart from making the relevant methods public, the
       <code>AbstractURLStreamHandlerService</code> stores the
-      <code>URLStreamHandlerSetter</code> object in a private variable. To make the
-      <code>setURL</code> method work properly, it overrides the
+      <code>URLStreamHandlerSetter</code> object in a private variable. To
+      make the <code>setURL</code> method work properly, it overrides the
       <code>setURL</code> method to invoke the <code>setURL</code> method on
       the saved <code>URLStreamHandlerSetter</code> object rather then the
       <code>URLStreamHandler.setURL</code> method. This means that a subclass

--- a/osgi.specs/docbook/core/055/framework.servicehooks.xml
+++ b/osgi.specs/docbook/core/055/framework.servicehooks.xml
@@ -16,7 +16,6 @@
    
     SPDX-License-Identifier: Apache-2.0 
  -->
-
 <chapter label="55" revision="$Id$"
          version="5.0" xml:id="framework.servicehooks"
          xmlns="http://docbook.org/ns/docbook"
@@ -531,14 +530,14 @@
     linkend="org.osgi.framework.hooks.service.EventListenerHook"
     xrefstyle="hyperlink"/> object as a service with the framework. The
     framework must then send a service events to all the registered hooks. The
-    calling order of the hooks is defined by the reversed
-    <code>compareTo</code> ordering of their Service Reference objects. That
-    is, the service with the highest ranking number is called first. Event
-    Listener Hooks are called <emphasis>after</emphasis> the event is
-    generated but <emphasis>before</emphasis> they are filtered by the
-    optional filter expressions of the service listeners. Before the return,
-    the handler can remove bundles from the given list. This allows an Event
-    Listener Hook to hide service events for specific bundles.</para>
+    calling order of the hooks is defined by ranking order, see <xref
+    linkend="framework.service.servicerankingorder"/>. That is, the service
+    with the highest ranking is called first. Event Listener Hooks are called
+    <emphasis>after</emphasis> the event is generated but
+    <emphasis>before</emphasis> they are filtered by the optional filter
+    expressions of the service listeners. Before the return, the handler can
+    remove bundles from the given list. This allows an Event Listener Hook to
+    hide service events for specific bundles.</para>
 
     <para>The model is depicted in the <xref linkend="i1664951"/>. A target
     bundle listens for service events but these events can be filtered by the
@@ -630,10 +629,10 @@
     registry with the <code>getServiceReference</code> or
     <code>getServiceReferences</code> methods. A registered Find Hook service
     gets a chance to inspect the returned set of service references and can
-    optionally shrink the set of returned services. The order in which the
-    find hooks are called is the reverse <code>compareTo</code> ordering of
-    their Service References. That is, the service with the highest ranking
-    number must be called first.</para>
+    optionally shrink the set of returned services. The calling order of the
+    hooks is defined by ranking order, see <xref
+    linkend="framework.service.servicerankingorder"/>. That is, the service
+    with the highest ranking number must be called first.</para>
 
     <itemizedlist>
       <listitem>


### PR DESCRIPTION
We improve the javadoc for ServiceReference.compareTo for the natural
order and state that the ranking order, which is defined in the Core
spec, is the reverse of the natural order.

We then update the javadoc and spec text to consistently use the terms
natural order or ranking order, as appropriate, instead of restating
how to sort on service.ranking and service.id service properties.

Fixes https://github.com/osgi/osgi/issues/400
