### PR TITLE
bundle annotations: Replace use of enum types

### DIFF
--- a/org.osgi.annotation.bundle/src/org/osgi/annotation/bundle/Export.java
+++ b/org.osgi.annotation.bundle/src/org/osgi/annotation/bundle/Export.java
@@ -81,19 +81,21 @@ public @interface Export {
 	 * If not specified, the {@link Substitution#CALCULATED} substitution
 	 * policy is used for this package.
 	 */
-	Substitution substitution() default Substitution.CALCULATED;
+	String substitution() default Substitution.CALCULATED;
 
 	/**
 	 * Substitution policy for this package.
 	 */
-	public enum Substitution {
+	public final class Substitution {
+		private Substitution() {
+		}
 		/**
 		 * Use a consumer type version range for the import package clause when
 		 * substitutably importing a package.
 		 * 
 		 * @see ConsumerType
 		 */
-		CONSUMER,
+		public static final String	CONSUMER	= "CONSUMER";
 
 		/**
 		 * Use a provider type version range for the import package clause when
@@ -101,17 +103,17 @@ public @interface Export {
 		 * 
 		 * @see ProviderType
 		 */
-		PROVIDER,
+		public static final String	PROVIDER	= "PROVIDER";
 
 		/**
 		 * The package must not be substitutably imported.
 		 */
-		NOIMPORT,
+		public static final String	NOIMPORT	= "NOIMPORT";
 
 		/**
 		 * The policy value is calculated by inspection of the classes in the
 		 * package.
 		 */
-		CALCULATED
+		public static final String	CALCULATED	= "CALCULATED";
 	}
 }

--- a/org.osgi.annotation.bundle/src/org/osgi/annotation/bundle/Requirement.java
+++ b/org.osgi.annotation.bundle/src/org/osgi/annotation/bundle/Requirement.java
@@ -119,32 +119,23 @@ public @interface Requirement {
 	 * If not specified, the {@code cardinality} directive is omitted from the
 	 * requirement clause.
 	 */
-	Cardinality cardinality() default Cardinality.SINGLE;
+	String cardinality() default Cardinality.SINGLE;
 
 	/**
 	 * Cardinality for this requirement.
 	 */
-	public enum Cardinality {
+	public final class Cardinality {
+		private Cardinality() {
+		}
 		/**
 		 * Indicates if the requirement can only be wired a single time.
 		 */
-		SINGLE("single"), // Namespace.CARDINALITY_SINGLE
+		public static final String	SINGLE		= "SINGLE";		// Namespace.CARDINALITY_SINGLE
 
 		/**
 		 * Indicates if the requirement can be wired multiple times.
 		 */
-		MULTIPLE("multiple"); // Namespace.CARDINALITY_MULTIPLE
-
-		private final String value;
-
-		Cardinality(String value) {
-			this.value = value;
-		}
-
-		@Override
-		public String toString() {
-			return value;
-		}
+		public static final String	MULTIPLE	= "MULTIPLE";	// Namespace.CARDINALITY_MULTIPLE
 	}
 
 	/**
@@ -157,33 +148,24 @@ public @interface Requirement {
 	 * If not specified, the {@code resolution} directive is omitted from the
 	 * requirement clause.
 	 */
-	Resolution resolution() default Resolution.MANDATORY;
+	String resolution() default Resolution.MANDATORY;
 
 	/**
 	 * Resolution for this requirement.
 	 */
-	public enum Resolution {
+	public final class Resolution {
+		private Resolution() {
+		}
 		/**
 		 * A mandatory requirement forbids the bundle to resolve when the
 		 * requirement is not satisfied.
 		 */
-		MANDATORY("mandatory"), // Namespace.RESOLUTION_MANDATORY
+		public static final String	MANDATORY	= "MANDATORY";	// Namespace.RESOLUTION_MANDATORY
 
 		/**
 		 * An optional requirement allows a bundle to resolve even if the
 		 * requirement is not satisfied.
 		 */
-		OPTIONAL("optional"); // Namespace.RESOLUTION_OPTIONAL
-
-		private final String value;
-
-		Resolution(String value) {
-			this.value = value;
-		}
-
-		@Override
-		public String toString() {
-			return value;
-		}
+		public static final String	OPTIONAL	= "OPTIONAL";	// Namespace.RESOLUTION_OPTIONAL
 	}
 }

--- a/org.osgi.annotation.bundle/src/org/osgi/annotation/bundle/package-info.java
+++ b/org.osgi.annotation.bundle/src/org/osgi/annotation/bundle/package-info.java
@@ -17,13 +17,13 @@
  *******************************************************************************/
 
 /**
- * OSGi Bundle Annotations Package Version 1.1.
+ * OSGi Bundle Annotations Package Version 2.0.
  * <p>
  * This package is not used at runtime.
  *
  * @author $Id$
  */
-@Version("1.1.1")
+@Version("2.0")
 package org.osgi.annotation.bundle;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Using enum types in the CLASS retention bundle annotations is causing
issues for those using the annotations. Various tools, such as javadoc,
attempt to reify the elements in the annotations and since the
osgi.annotation jar is generally a scope=provided dependency, the enum
types are not available to downstream users of the jars using the
OSGi annotations and so tools generates an annoying warning.

See https://github.com/quarkusio/quarkus/issues/19970 and
https://github.com/eclipse/microprofile-config/issues/716.

To address this, we replace the enum classes with simple classes holding
string constants and change the annotation elements returning the enum
values to return string values. This is generally source compatible
with usage of the OSGi annotations. Since these are CLASS retention
annotations, they are not visible at runtime and so only tools, like
Bnd, which process the annotations at tool time are affected.

Bnd will seamlessly handle old and new annotations using the old enum
values or the new string values. So moving to using the updated OSGi
annotations will not require updating to use a newer version of Bnd.
Bnd 6.2 is being updated to better handle these changes including
validation of the string values since a string return type is open
ended while an enum return type is not.

