### PR TITLE
[tck] org.osgi.service.jdbc - enhancements

### DIFF
--- a/org.osgi.test.cases.jdbc/bnd.bnd
+++ b/org.osgi.test.cases.jdbc/bnd.bnd
@@ -18,3 +18,5 @@ Import-Package: ${-signaturetest}, *
 	org.osgi.impl.bundle.derby; version=latest
 
 -signaturetest                      = org.osgi.service.jdbc
+
+-runproperties.tck.cardinality: org.osgi.tck.cardinality=SHOULD


### PR DESCRIPTION
* switch to junit 5
* use osgi-test
* remove tests on custom properties ("junk" -- derby related test)
* test (notNull) return value of DataSource and Driver methods

Discussion:
Spec uses `should` and `optional` this would be a way to test this:
* test "should" with separate @Tag and "@EnabledIfSystemProperty"



