### PR TITLE
[jaxrs] Minor TCK fixes to improve implementation compatibility

### DIFF
--- a/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/ClientTestCase.java
+++ b/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/ClientTestCase.java
@@ -64,7 +64,7 @@ public class ClientTestCase extends AbstractJAXRSTestCase {
 
 		String baseURI = getBaseURI();
 
-		WebTarget target = c.target(baseURI + "/whiteboard/resource");
+		WebTarget target = c.target(baseURI).path("whiteboard/resource");
 
 		assertEquals(NOT_FOUND.getStatusCode(),
 				target.request().get().getStatusInfo().getStatusCode());
@@ -124,7 +124,8 @@ public class ClientTestCase extends AbstractJAXRSTestCase {
 
 			String baseURI = getBaseURI();
 
-			WebTarget target = c.target(baseURI + "/whiteboard/async/{name}");
+			WebTarget target = c.target(baseURI)
+					.path("whiteboard/async/{name}");
 
 			Promise<String> p = target.resolveTemplate("name", "Bob")
 					.request()

--- a/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/SSETestCase.java
+++ b/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/SSETestCase.java
@@ -59,7 +59,7 @@ public class SSETestCase extends AbstractJAXRSTestCase {
 
 		String baseURI = getBaseURI();
 
-		WebTarget target = c.target(baseURI + "/whiteboard/stream");
+		WebTarget target = c.target(baseURI).path("whiteboard/stream");
 
 		Dictionary<String,Object> properties = new Hashtable<>();
 		properties.put(JaxrsWhiteboardConstants.JAX_RS_RESOURCE, Boolean.TRUE);


### PR DESCRIPTION
The JAX-RS TCK makes heavy use of String concatenation to build URIs, but it isn't very careful about introducing extra / characters. Extra / characters can cause failures in some JAX-RS clients so we should use the built in API methods to avoid these problema

Signed-off-by: Tim Ward <timothyjward@apache.org>