### PR TITLE
[jaxrs] Improve the TCK compatibility with the JAX-RS specification

### DIFF
--- a/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/SSETestCase.java
+++ b/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/SSETestCase.java
@@ -95,7 +95,7 @@ public class SSETestCase extends AbstractJAXRSTestCase {
 
 			assertNull(ref.get());
 
-			assertEquals(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), list);
+			assertEquals(Arrays.asList(42, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9), list);
 		
 		} finally {
 			reg.unregister();

--- a/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/resources/SseResource.java
+++ b/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/resources/SseResource.java
@@ -19,6 +19,7 @@ package org.osgi.test.cases.jaxrs.resources;
 
 import static javax.ws.rs.core.HttpHeaders.LAST_EVENT_ID_HEADER;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.GET;
@@ -50,22 +51,25 @@ public class SseResource {
 	SseEventSink sink) throws NoContentException {
 
 		int id;
+		boolean hello;
 		if (lastId == null) {
 			id = -1;
+			hello = true;
 		} else {
 			id = Integer.parseInt(lastId);
 			if (id >= 9) {
 				throw new NoContentException("No events after " + lastId);
 			}
+			hello = false;
 		}
 		
 		new Thread(() -> {
 
-			CompletionStage< ? > cs = sink.send(sse.newEventBuilder()
+			CompletionStage< ? > cs = hello ? sink.send(sse.newEventBuilder()
 					.reconnectDelay(500)
 					.comment("Hello")
 					.data(42)
-					.build());
+					.build()) : CompletableFuture.completedFuture(null);
 
 			try {
 				for (int i = id + 1; i < 10; i++) {

--- a/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/resources/SseResource.java
+++ b/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/resources/SseResource.java
@@ -17,14 +17,17 @@
  *******************************************************************************/
 package org.osgi.test.cases.jaxrs.resources;
 
-import java.util.concurrent.CompletableFuture;
+import static javax.ws.rs.core.HttpHeaders.LAST_EVENT_ID_HEADER;
+
 import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.NoContentException;
 import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseEventSink;
 
@@ -42,15 +45,33 @@ public class SseResource {
 
 	@GET
 	@Produces(MediaType.SERVER_SENT_EVENTS)
-	public void stream(@Context SseEventSink sink) {
+	public void stream(@HeaderParam(LAST_EVENT_ID_HEADER)
+	String lastId, @Context
+	SseEventSink sink) throws NoContentException {
+
+		int id;
+		if (lastId == null) {
+			id = -1;
+		} else {
+			id = Integer.parseInt(lastId);
+			if (id >= 9) {
+				throw new NoContentException("No events after " + lastId);
+			}
+		}
+		
 		new Thread(() -> {
 
-			CompletionStage< ? > cs = CompletableFuture.completedFuture(null);
+			CompletionStage< ? > cs = sink.send(sse.newEventBuilder()
+					.reconnectDelay(500)
+					.comment("Hello")
+					.data(42)
+					.build());
 
 			try {
-				for (int i = 0; i < 10; i++) {
+				for (int i = id + 1; i < 10; i++) {
 					Thread.sleep(500);
 					cs = cs.thenCombine(sink.send(sse.newEventBuilder()
+							.id(String.valueOf(i))
 							.data(i)
 							.mediaType(type)
 							.build()), (a, b) -> null);


### PR DESCRIPTION
The JAX-RS SseEventSource is somewhat poorly specified, in that it will continually reconnect at the end of a stream, and is not required to notify of completion in this case. The server is expected to send a 204 response if the client is to stop connecting, at which point the client is notified that the stream has ended.

This change also adds an explicit message to set the client reconnect time to be one 'tick' which is 500 ms, ensuring that default delays in the client will not cause the test to time out.

Signed-off-by: Tim Ward <timothyjward@apache.org>