### PR TITLE
[docs] fix typo in servicehook spec

### DIFF
--- a/osgi.specs/docbook/core/055/framework.servicehooks.xml
+++ b/osgi.specs/docbook/core/055/framework.servicehooks.xml
@@ -350,7 +350,7 @@
       <para>The following example shows how to hide a specific Service
       Reference from a specific bundle.</para>
 
-      <programlisting>public class Hide implementsEventListenerHook, FindHook {
+      <programlisting>public class Hide implements EventListenerHook, FindHook {
     final Bundle           bundle;
     final ServiceReference reference;
     final BundleContext    context;


### PR DESCRIPTION
Signed-off-by: Stefan Bischof <stbischof@bipolis.org>