### PR TITLE
JAX-RS TCK - Move to JUnit 5 and osgi-test

### DIFF
--- a/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/AbstractJAXRSTestCase.java
+++ b/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/AbstractJAXRSTestCase.java
@@ -19,6 +19,7 @@
 
 package org.osgi.test.cases.jaxrs.junit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.osgi.service.jaxrs.runtime.JaxrsServiceRuntimeConstants.JAX_RS_SERVICE_ENDPOINT;
 
 import java.io.ByteArrayOutputStream;
@@ -31,35 +32,46 @@ import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.PrototypeServiceFactory;
 import org.osgi.framework.ServiceFactory;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.jaxrs.runtime.JaxrsServiceRuntime;
 import org.osgi.test.cases.jaxrs.util.ServiceUpdateHelper;
-import org.osgi.test.support.OSGiTestCase;
+import org.osgi.test.common.annotation.InjectBundleContext;
+import org.osgi.test.junit5.context.BundleContextExtension;
 
 /**
  * This test covers the lifecycle behaviours described in section 151.4.2
  */
-public abstract class AbstractJAXRSTestCase extends OSGiTestCase {
+@ExtendWith(BundleContextExtension.class)
+public abstract class AbstractJAXRSTestCase {
 	
+	@InjectBundleContext
+	protected BundleContext							context;
+
 	protected CloseableHttpClient					client;
 
 	protected ServiceUpdateHelper					helper;
 
 	protected ServiceReference<JaxrsServiceRuntime>	runtime;
 
+	@BeforeEach
 	public void setUp() {
 		client = HttpClients.createDefault();
 
-		helper = new ServiceUpdateHelper(getContext());
+		helper = new ServiceUpdateHelper(context);
 		helper.open();
 
 		runtime = helper.awaitRuntime(5000);
 	}
 
+	@AfterEach
 	public void tearDown() throws IOException {
 		helper.close();
 		client.close();

--- a/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/CapabilityTestCase.java
+++ b/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/CapabilityTestCase.java
@@ -19,6 +19,7 @@ package org.osgi.test.cases.jaxrs.junit;
 
 import static java.lang.String.valueOf;
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertTrue;
 import static org.osgi.namespace.contract.ContractNamespace.CAPABILITY_VERSION_ATTRIBUTE;
 import static org.osgi.namespace.contract.ContractNamespace.CONTRACT_NAMESPACE;
 import static org.osgi.namespace.implementation.ImplementationNamespace.IMPLEMENTATION_NAMESPACE;
@@ -37,6 +38,7 @@ import java.util.Set;
 
 import javax.ws.rs.client.ClientBuilder;
 
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Version;
 import org.osgi.framework.wiring.BundleCapability;
@@ -58,6 +60,7 @@ public class CapabilityTestCase extends AbstractJAXRSTestCase {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testJaxRsServiceRuntimeServiceCapability() throws Exception {
 
 		List<BundleCapability> capabilities = runtime.getBundle()
@@ -104,6 +107,7 @@ public class CapabilityTestCase extends AbstractJAXRSTestCase {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testJaxRsClientBuilderServiceCapability() throws Exception {
 
 		List<BundleCapability> capabilities = runtime.getBundle()
@@ -150,6 +154,7 @@ public class CapabilityTestCase extends AbstractJAXRSTestCase {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testSseEventSourceFactoryServiceCapability() throws Exception {
 
 		List<BundleCapability> capabilities = runtime.getBundle()
@@ -194,6 +199,7 @@ public class CapabilityTestCase extends AbstractJAXRSTestCase {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testJaxRsServiceWhiteboardImplementationCapability()
 			throws Exception {
 
@@ -201,7 +207,7 @@ public class CapabilityTestCase extends AbstractJAXRSTestCase {
 		boolean uses = false;
 		boolean version = false;
 
-		bundles: for (Bundle bundle : getContext().getBundles()) {
+		bundles: for (Bundle bundle : context.getBundles()) {
 			List<BundleCapability> capabilities = bundle
 					.adapt(BundleWiring.class)
 					.getCapabilities(IMPLEMENTATION_NAMESPACE);
@@ -256,6 +262,7 @@ public class CapabilityTestCase extends AbstractJAXRSTestCase {
 	 * 
 	 * @throws Exception
 	 */
+	@Test
 	public void testJaxRsContractCapability()
 			throws Exception {
 		
@@ -263,7 +270,7 @@ public class CapabilityTestCase extends AbstractJAXRSTestCase {
 		boolean uses = false;
 		boolean version = false;
 		
-		bundles: for (Bundle bundle : getContext().getBundles()) {
+		bundles: for (Bundle bundle : context.getBundles()) {
 			List<BundleCapability> capabilities = bundle
 					.adapt(BundleWiring.class)
 					.getCapabilities(CONTRACT_NAMESPACE);

--- a/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/ClientTestCase.java
+++ b/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/ClientTestCase.java
@@ -18,6 +18,10 @@
 package org.osgi.test.cases.jaxrs.junit;
 
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.osgi.framework.Constants.SCOPE_PROTOTYPE;
 import static org.osgi.framework.Constants.SERVICE_SCOPE;
 
@@ -30,15 +34,19 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.ServiceReference;
-import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.jaxrs.client.PromiseRxInvoker;
 import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
 import org.osgi.test.cases.jaxrs.resources.AsyncWhiteboardResource;
 import org.osgi.test.cases.jaxrs.resources.WhiteboardResource;
+import org.osgi.test.common.annotation.InjectService;
+import org.osgi.test.common.service.ServiceAware;
+import org.osgi.test.junit5.service.ServiceExtension;
 import org.osgi.util.promise.Promise;
-import org.osgi.util.tracker.ServiceTracker;
 
+@ExtendWith(ServiceExtension.class)
 public class ClientTestCase extends AbstractJAXRSTestCase {
 	
 	/**
@@ -47,50 +55,43 @@ public class ClientTestCase extends AbstractJAXRSTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public void testJaxRsClientService() throws Exception {
+	@Test
+	public void testJaxRsClientService(@InjectService
+	ServiceAware<ClientBuilder> builderService) throws Exception {
 
-		ServiceTracker<ClientBuilder,ClientBuilder> tracker = new ServiceTracker<>(
-				getContext(), ClientBuilder.class, null);
-		tracker.open();
+		assertNotNull(builderService.waitForService(2000));
 
-		assertNotNull(tracker.waitForService(2000));
-
-		for (ServiceReference<ClientBuilder> ref : tracker.getTracked()
-				.keySet()) {
+		for (ServiceReference<ClientBuilder> ref : builderService
+				.getServiceReferences()) {
 			assertEquals(SCOPE_PROTOTYPE, ref.getProperty(SERVICE_SCOPE));
 		}
 
-		Client c = tracker.getService().build();
+		Client c = builderService.getService().build();
 
 		String baseURI = getBaseURI();
 
 		WebTarget target = c.target(baseURI).path("whiteboard/resource");
 
+		// Do a get
 		assertEquals(NOT_FOUND.getStatusCode(),
 				target.request().get().getStatusInfo().getStatusCode());
 
+		// Register a resource
 		Dictionary<String,Object> properties = new Hashtable<>();
 		properties.put(JaxrsWhiteboardConstants.JAX_RS_RESOURCE, Boolean.TRUE);
 
 		Promise<Void> awaitSelection = helper.awaitModification(runtime, 5000);
 
-		ServiceRegistration<WhiteboardResource> reg = getContext()
-				.registerService(WhiteboardResource.class,
+		context.registerService(WhiteboardResource.class,
 						new WhiteboardResource(), properties);
 
-		try {
+		awaitSelection.getValue();
 
-			awaitSelection.getValue();
+		// Do another get
 
-			// Do another get
-
-			assertEquals("[buzz, fizz, fizzbuzz]",
-					target.request().get(String.class));
+		assertEquals("[buzz, fizz, fizzbuzz]",
+				target.request().get(String.class));
 		
-		} finally {
-			reg.unregister();
-			tracker.close();
-		}
 	}
 
 	/**
@@ -98,54 +99,44 @@ public class ClientTestCase extends AbstractJAXRSTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public void testJaxRsPromiseRxInvoker() throws Exception {
+	@Test
+	public void testJaxRsPromiseRxInvoker(@InjectService
+	ServiceAware<ClientBuilder> builderService) throws Exception {
 
-		ServiceTracker<ClientBuilder,ClientBuilder> tracker = new ServiceTracker<>(
-				getContext(), ClientBuilder.class, null);
-		tracker.open();
+		assertNotNull(builderService.waitForService(2000));
 
-		assertNotNull(tracker.waitForService(2000));
-
-		Client c = tracker.getService().build();
+		Client c = builderService.getService().build();
 
 		Dictionary<String,Object> properties = new Hashtable<>();
 		properties.put(JaxrsWhiteboardConstants.JAX_RS_RESOURCE, Boolean.TRUE);
 
 		Promise<Void> awaitSelection = helper.awaitModification(runtime, 5000);
 
-		ServiceRegistration<AsyncWhiteboardResource> reg = getContext()
-				.registerService(AsyncWhiteboardResource.class,
+		context.registerService(AsyncWhiteboardResource.class,
 						new AsyncWhiteboardResource(() -> {}, () -> {}),
 						properties);
 
-		try {
+		awaitSelection.getValue();
 
-			awaitSelection.getValue();
+		String baseURI = getBaseURI();
 
-			String baseURI = getBaseURI();
+		WebTarget target = c.target(baseURI).path("whiteboard/async/{name}");
 
-			WebTarget target = c.target(baseURI)
-					.path("whiteboard/async/{name}");
+		Promise<String> p = target.resolveTemplate("name", "Bob")
+				.request()
+				.rx(PromiseRxInvoker.class)
+				.get(String.class);
 
-			Promise<String> p = target.resolveTemplate("name", "Bob")
-					.request()
-					.rx(PromiseRxInvoker.class)
-					.get(String.class);
+		assertFalse(p.isDone());
 
-			assertFalse(p.isDone());
+		Semaphore s = new Semaphore(0);
 
-			Semaphore s = new Semaphore(0);
+		p.onResolve(s::release);
 
-			p.onResolve(s::release);
+		assertTrue(s.tryAcquire(5, TimeUnit.SECONDS));
 
-			assertTrue(s.tryAcquire(5, TimeUnit.SECONDS));
+		assertEquals("Bob", p.getValue());
 
-			assertEquals("Bob", p.getValue());
-
-		} finally {
-			reg.unregister();
-			tracker.close();
-		}
 	}
 
 }


### PR DESCRIPTION
The JAX-RS TCK made heavy use of trackers and try/finally to manage testing. This can be dramatically simplified by using the osgi-test library and JUnit5, which will automatically unregister/unget services used in tests.