### PR TITLE
[jaxrs-tck] Ensure that the correct release is waited for in testing

### DIFF
--- a/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/ResourceLifecyleTestCase.java
+++ b/org.osgi.test.cases.jaxrs/src/org/osgi/test/cases/jaxrs/junit/ResourceLifecyleTestCase.java
@@ -242,6 +242,9 @@ public class ResourceLifecyleTestCase extends AbstractJAXRSTestCase {
 
 		String baseURI = getBaseURI();
 
+		// Clear the semaphore as setup may involve get/release of the service
+		releaseSemaphore.drainPermits();
+
 		// Do a get
 
 		CloseableHttpResponse httpResponse = client.execute(


### PR DESCRIPTION
JAX-RS whiteboard implementations are permitted to get/release whiteboard services as part of setup in order to introspect them. One TCK test in particular (async lifecycle) tracks the service release to avoid timing bugs. This test failed to clear any pre-existing releases before running the actual test code.

Signed-off-by: Tim Ward <timothyjward@apache.org>