### PR TITLE
Relax throwing of IllegalStateException when cleaning up things

### DIFF
--- a/org.osgi.framework/src/org/osgi/framework/Bundle.java
+++ b/org.osgi.framework/src/org/osgi/framework/Bundle.java
@@ -359,8 +359,7 @@ public interface Bundle extends Comparable<Bundle> {
 	 *         {@link BundleException#RESOLVE_ERROR},
 	 *         {@link BundleException#STATECHANGE_ERROR}, and
 	 *         {@link BundleException#ACTIVATOR_ERROR}.
-	 * @throws IllegalStateException If this bundle has been uninstalled or this
-	 *         bundle tries to change its own state.
+	 * @throws IllegalStateException If this bundle has been uninstalled.
 	 * @throws SecurityException If the caller does not have the appropriate
 	 *         {@code AdminPermission[this,EXECUTE]}, and the Java Runtime
 	 *         Environment supports permissions.
@@ -380,8 +379,7 @@ public interface Bundle extends Comparable<Bundle> {
 	 *         {@link BundleException#RESOLVE_ERROR},
 	 *         {@link BundleException#STATECHANGE_ERROR}, and
 	 *         {@link BundleException#ACTIVATOR_ERROR}.
-	 * @throws IllegalStateException If this bundle has been uninstalled or this
-	 *         bundle tries to change its own state.
+	 * @throws IllegalStateException If this bundle has been uninstalled.
 	 * @throws SecurityException If the caller does not have the appropriate
 	 *         {@code AdminPermission[this,EXECUTE]}, and the Java Runtime
 	 *         Environment supports permissions.
@@ -451,8 +449,7 @@ public interface Bundle extends Comparable<Bundle> {
 	 * @throws BundleException BundleException types thrown by this method
 	 *         include: {@link BundleException#STATECHANGE_ERROR} and
 	 *         {@link BundleException#ACTIVATOR_ERROR}.
-	 * @throws IllegalStateException If this bundle has been uninstalled or this
-	 *         bundle tries to change its own state.
+	 * @throws IllegalStateException If this bundle has been uninstalled.
 	 * @throws SecurityException If the caller does not have the appropriate
 	 *         {@code AdminPermission[this,EXECUTE]}, and the Java Runtime
 	 *         Environment supports permissions.
@@ -469,8 +466,7 @@ public interface Bundle extends Comparable<Bundle> {
 	 * @throws BundleException BundleException types thrown by this method
 	 *         include: {@link BundleException#STATECHANGE_ERROR} and
 	 *         {@link BundleException#ACTIVATOR_ERROR}.
-	 * @throws IllegalStateException If this bundle has been uninstalled or this
-	 *         bundle tries to change its own state.
+	 * @throws IllegalStateException If this bundle has been uninstalled.
 	 * @throws SecurityException If the caller does not have the appropriate
 	 *         {@code AdminPermission[this,EXECUTE]}, and the Java Runtime
 	 *         Environment supports permissions.
@@ -554,8 +550,7 @@ public interface Bundle extends Comparable<Bundle> {
 	 *         {@link BundleException#RESOLVE_ERROR},
 	 *         {@link BundleException#STATECHANGE_ERROR}, and
 	 *         {@link BundleException#ACTIVATOR_ERROR}.
-	 * @throws IllegalStateException If this bundle has been uninstalled or this
-	 *         bundle tries to change its own state.
+	 * @throws IllegalStateException If this bundle has been uninstalled.
 	 * @throws SecurityException If the caller does not have the appropriate
 	 *         {@code AdminPermission[this,LIFECYCLE]} for both the current
 	 *         bundle and the updated bundle, and the Java Runtime Environment
@@ -581,8 +576,7 @@ public interface Bundle extends Comparable<Bundle> {
 	 *         {@link BundleException#RESOLVE_ERROR},
 	 *         {@link BundleException#STATECHANGE_ERROR}, and
 	 *         {@link BundleException#ACTIVATOR_ERROR}.
-	 * @throws IllegalStateException If this bundle has been uninstalled or this
-	 *         bundle tries to change its own state.
+	 * @throws IllegalStateException If this bundle has been uninstalled.
 	 * @throws SecurityException If the caller does not have the appropriate
 	 *         {@code AdminPermission[this,LIFECYCLE]} for both the current
 	 *         bundle and the updated bundle, and the Java Runtime Environment

--- a/org.osgi.framework/src/org/osgi/framework/Bundle.java
+++ b/org.osgi.framework/src/org/osgi/framework/Bundle.java
@@ -604,8 +604,8 @@ public interface Bundle extends Comparable<Bundle> {
 	 * <p>
 	 * The following steps are required to uninstall a bundle:
 	 * <ol>
-	 * <li>If this bundle's state is {@code UNINSTALLED} then an
-	 * {@code IllegalStateException} is thrown.</li>
+	 * <li>If this bundle's state is {@code UNINSTALLED}, then this method does
+	 * nothing and returns.</li>
 	 * <li>If this bundle's state is {@code ACTIVE}, {@code STARTING} or
 	 * {@code STOPPING}, this bundle is stopped as described in the
 	 * {@code Bundle.stop} method. If {@code Bundle.stop} throws an exception, a
@@ -637,8 +637,6 @@ public interface Bundle extends Comparable<Bundle> {
 	 *         does not complete in a timely manner. BundleException types
 	 *         thrown by this method include:
 	 *         {@link BundleException#STATECHANGE_ERROR}
-	 * @throws IllegalStateException If this bundle has been uninstalled or this
-	 *         bundle tries to change its own state.
 	 * @throws SecurityException If the caller does not have the appropriate
 	 *         {@code AdminPermission[this,LIFECYCLE]}, and the Java Runtime
 	 *         Environment supports permissions.

--- a/org.osgi.framework/src/org/osgi/framework/BundleContext.java
+++ b/org.osgi.framework/src/org/osgi/framework/BundleContext.java
@@ -70,11 +70,9 @@ import org.osgi.annotation.versioning.ProviderType;
  * called (for example, {@link ServiceListener}s for
  * {@link ServiceEvent#UNREGISTERING} events and {@link ServiceFactory}s for
  * unget operations), those other bundles can observe the stopping bundle in the
- * {@code STOPPING} state but with an invalid {@code BundleContext} object. If
- * the {@code BundleContext} object is used after it has become invalid, an
- * {@code IllegalStateException} must be thrown. The {@code BundleContext}
- * object must never be reused after its context bundle is stopped.
- * 
+ * {@code STOPPING} state but with an invalid {@code BundleContext} object. The
+ * {@code BundleContext} object must never be reused after its context bundle is
+ * stopped.
  * <p>
  * Two {@code BundleContext} objects are equal if they both refer to the same
  * execution context of a bundle. The Framework is the only entity that can
@@ -105,6 +103,7 @@ public interface BundleContext extends BundleReference {
 	 * @param key The name of the requested property.
 	 * @return The value of the requested property, or {@code null} if the
 	 *         property is undefined.
+	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 * @throws SecurityException If the caller does not have the appropriate
 	 *         {@code PropertyPermission} to read the property, and the Java
 	 *         Runtime Environment supports permissions.
@@ -214,6 +213,7 @@ public interface BundleContext extends BundleReference {
 	 * @param id The identifier of the bundle to retrieve.
 	 * @return A {@code Bundle} object or {@code null} if the identifier does
 	 *         not match any installed bundle.
+	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 */
 	Bundle getBundle(long id);
 
@@ -227,6 +227,7 @@ public interface BundleContext extends BundleReference {
 	 * 
 	 * @return An array of {@code Bundle} objects, one object per installed
 	 *         bundle.
+	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 */
 	Bundle[] getBundles();
 
@@ -300,10 +301,10 @@ public interface BundleContext extends BundleReference {
 	 * 
 	 * <p>
 	 * If {@code listener} is not contained in this context bundle's list of
-	 * listeners, this method does nothing.
+	 * listeners or this BundleContext is no longer valid, this method does
+	 * nothing.
 	 * 
 	 * @param listener The {@code ServiceListener} to be removed.
-	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 */
 	void removeServiceListener(ServiceListener listener);
 
@@ -333,10 +334,10 @@ public interface BundleContext extends BundleReference {
 	 * 
 	 * <p>
 	 * If {@code listener} is not contained in the context bundle's list of
-	 * listeners, this method does nothing.
+	 * listeners or this BundleContext is no longer valid, this method does
+	 * nothing.
 	 * 
 	 * @param listener The {@code BundleListener} object to be removed.
-	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 * @throws SecurityException If listener is a
 	 *         {@code SynchronousBundleListener} and the caller does not have
 	 *         the appropriate {@code AdminPermission[context bundle,LISTENER]},
@@ -366,10 +367,10 @@ public interface BundleContext extends BundleReference {
 	 * 
 	 * <p>
 	 * If {@code listener} is not contained in the context bundle's list of
-	 * listeners, this method does nothing.
+	 * listeners or this BundleContext is no longer valid, this method does
+	 * nothing.
 	 * 
 	 * @param listener The {@code FrameworkListener} object to be removed.
-	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 */
 	void removeFrameworkListener(FrameworkListener listener);
 
@@ -808,6 +809,8 @@ public interface BundleContext extends BundleReference {
 	 * <p>
 	 * The following steps are required to release the service object:
 	 * <ol>
+	 * <li>If this BundleContext is no longer valid, {@code false} is
+	 * returned.</li>
 	 * <li>If the context bundle's use count for the service is zero or the
 	 * service has been unregistered, {@code false} is returned.</li>
 	 * <li>The context bundle's use count for the service is decremented by one.
@@ -824,7 +827,6 @@ public interface BundleContext extends BundleReference {
 	 * @return {@code false} if the context bundle's use count for the service
 	 *         is zero or if the service has been unregistered; {@code true}
 	 *         otherwise.
-	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 * @throws IllegalArgumentException If the specified
 	 *         {@code ServiceReference} was not created by the same framework
 	 *         instance as this {@code BundleContext}.
@@ -925,6 +927,7 @@ public interface BundleContext extends BundleReference {
 	 * @param location The location of the bundle to retrieve.
 	 * @return A {@code Bundle} object or {@code null} if the location does not
 	 *         match any installed bundle.
+	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 * @since 1.6
 	 */
 	Bundle getBundle(String location);

--- a/org.osgi.framework/src/org/osgi/framework/ServiceObjects.java
+++ b/org.osgi.framework/src/org/osgi/framework/ServiceObjects.java
@@ -126,8 +126,6 @@ public interface ServiceObjects<S> {
 	 * 
 	 * @param service A service object previously provided by this
 	 *            {@code ServiceObjects} object.
-	 * @throws IllegalStateException If the BundleContext used to create this
-	 *             {@code ServiceObjects} object is no longer valid.
 	 * @throws IllegalArgumentException If the specified service object is
 	 *             {@code null} or was not provided by a {@code ServiceObjects}
 	 *             object for the associated service.

--- a/org.osgi.framework/src/org/osgi/framework/ServiceRegistration.java
+++ b/org.osgi.framework/src/org/osgi/framework/ServiceRegistration.java
@@ -89,6 +89,8 @@ public interface ServiceRegistration<S> {
 	 * <p>
 	 * The following steps are required to unregister a service:
 	 * <ol>
+	 * <li>If this {@code ServiceRegistration} object has already been
+	 * unregistered, then this method does nothing and returns.</li>
 	 * <li>The service is removed from the Framework service registry so that it
 	 * can no longer be obtained.</li>
 	 * <li>A service event of type {@link ServiceEvent#UNREGISTERING} is fired
@@ -107,8 +109,6 @@ public interface ServiceRegistration<S> {
 	 * </li>
 	 * </ol>
 	 * 
-	 * @throws IllegalStateException If this {@code ServiceRegistration} object
-	 *         has already been unregistered.
 	 * @see BundleContext#ungetService(ServiceReference)
 	 * @see ServiceFactory#ungetService(Bundle, ServiceRegistration, Object)
 	 */


### PR DESCRIPTION
When calling clean up methods like 

* Bundle.uninstall
* BundleContext.removeBundleListener
* BundleContext.removeFrameworkListener
* BundleContext.removeServiceListener
* BundleContext.ungetService
* ServiceObjects.ungetService
* ServiceRegistration.unregister

receiving an `IllegalStateException` because clean up action has already been performed (perhaps by the stopping of a bundle which closes its `BundleContext`) is unhelpful. There is nothing the caller can really do since they were
in the processing of cleaning up something that was already cleaned up. So callers
often have to write defensive try-catch statements to catch
and ignore a thrown IllegalStateException.

