### PR TITLE
metatype: Add missing comma to code example in spec

### DIFF
--- a/osgi.specs/docbook/105/service.metatype.xml
+++ b/osgi.specs/docbook/105/service.metatype.xml
@@ -1483,7 +1483,7 @@ female=Female</programlisting>
 
       <programlisting>@ObjectClassDefinition(localization = "OSGI-INF/l10n/member",
     description = "%member.description",
-    name = "%member.name"
+    name = "%member.name",
     icon = @Icon(resource = "icon/member-32.png", size = 32))
 @interface Member {
   @AttributeDefinition(type = AttributeType.PASSWORD,


### PR DESCRIPTION
Fixes https://github.com/osgi/osgi/issues/465
