### PR TITLE
spec: Update links to Java SE docs

### DIFF
--- a/osgi.specs/docbook/100/service.remoteservices.xml
+++ b/osgi.specs/docbook/100/service.remoteservices.xml
@@ -1405,7 +1405,7 @@ com.acme.rmi.path = service-id/24</programlisting>
 
       <bibliomixed xml:id="i1721171"><title>Java Language
       Specification</title><biblioid class="uri"><link
-      xlink:href="http://docs.oracle.com/javase/specs/"/></biblioid></bibliomixed>
+      xlink:href="https://docs.oracle.com/javase/specs/"/></biblioid></bibliomixed>
     </bibliolist>
   </section>
 </chapter>

--- a/osgi.specs/docbook/112/service.component.xml
+++ b/osgi.specs/docbook/112/service.component.xml
@@ -6354,7 +6354,7 @@ public class MyComponent implements AcmeService {}</programlisting>
 
       <bibliomixed xml:id="i1567926"><title>Java Properties
       File</title><biblioid class="uri"><link
-      xlink:href="http://docs.oracle.com/javase/7/docs/api/java/util/Properties.html"/></biblioid></bibliomixed>
+      xlink:href="https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html"/></biblioid></bibliomixed>
 
       <bibliomixed xml:id="i1636361"><title>Extensible Markup Language (XML)
       1.0</title><biblioid class="uri"><link

--- a/osgi.specs/docbook/126/service.jndi.xml
+++ b/osgi.specs/docbook/126/service.jndi.xml
@@ -1596,15 +1596,15 @@ ServicePermission ..JNDIProviderAdmin            REGISTER,GET</programlisting>
     <bibliolist>
       <bibliomixed xml:id="i3131859"><title>Java Naming and Directory
       Interface</title><biblioid class="uri"><link
-      xlink:href="http://docs.oracle.com/javase/6/docs/technotes/guides/jndi/index.html"/></biblioid></bibliomixed>
+      xlink:href="https://docs.oracle.com/javase/8/docs/technotes/guides/jndi/index.html"/></biblioid></bibliomixed>
 
-      <bibliomixed><title>Java Naming and Directory Interface Tutorial from
-      Sun Microsystems</title><biblioid class="uri"><link
-      xlink:href="http://download.oracle.com/javase/6/docs/technotes/guides/jndi/index.html"/></biblioid></bibliomixed>
+      <bibliomixed><title>Java Naming and Directory Interface
+      Tutorial</title><biblioid class="uri"><link
+      xlink:href="https://docs.oracle.com/javase/tutorial/jndi/index.html"/></biblioid></bibliomixed>
 
       <bibliomixed xml:id="i3109941"><title>JNDI Standard Property
       Names</title><biblioid class="uri"><link
-      xlink:href="http://download.oracle.com/javase/1.5.0/docs/api/javax/naming/Context.html"/></biblioid></bibliomixed>
+      xlink:href="https://docs.oracle.com/javase/8/docs/api/javax/naming/Context.html"/></biblioid></bibliomixed>
     </bibliolist>
   </section>
 </chapter>

--- a/osgi.specs/docbook/133/service.loader.xml
+++ b/osgi.specs/docbook/133/service.loader.xml
@@ -1120,7 +1120,7 @@ CapabilityPermission["osgi.serviceloader", PROVIDE]
     <bibliolist>
       <bibliomixed xml:id="i3255894"><title>Java Service Loader
       API</title><biblioid class="uri"><link
-      xlink:href="http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html"/></biblioid></bibliomixed>
+      xlink:href="https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html"/></biblioid></bibliomixed>
     </bibliolist>
   </section>
 </chapter>

--- a/osgi.specs/docbook/core/003/framework.module.xml
+++ b/osgi.specs/docbook/core/003/framework.module.xml
@@ -5791,7 +5791,7 @@ URL(String protocol, String host, String file)</programlisting>
       <bibliomixed
       xml:id="framework.module-ref.multireleasejar"><title>Multi-release JAR
       File</title><biblioid class="uri"><link
-      xlink:href="https://docs.oracle.com/javase/9/docs/specs/jar/jar.html#Multi-release"/></biblioid></bibliomixed>
+      xlink:href="https://docs.oracle.com/en/java/javase/17/docs/specs/jar/jar.html#multi-release-jar-files"/></biblioid></bibliomixed>
     </bibliolist>
   </section>
 </chapter>


### PR DESCRIPTION
Fix some old links to use functioning URLs.