### PR TITLE
Use a Java 8 compiled Jakarta RS API for javadoc generation

### DIFF
--- a/osgi.specs/bnd.bnd
+++ b/osgi.specs/bnd.bnd
@@ -20,7 +20,7 @@ batik_jars: ${findfile;${fop_home};batik*.jar},${findfile;${fop_home};xml-apis*.
     org.eclipse.persistence.jpa_spec; version=latest, \
     org.apache.geronimo.specs.geronimo-atinject_1.0_spec;version=1.1,\
     org.apache.geronimo.specs.geronimo-jcdi_2.0_spec;version=1.1,\
-    jakarta.ws.rs-api;version=latest,\
+    jakarta.ws.rs-api;version=3.0,\
     com.icl.saxon; version=latest, \
     ${template;batik_jars;${fop_home}/${@};version=file}
 


### PR DESCRIPTION
Signed-off-by: Tim Ward <timothyjward@apache.org>