### PR TITLE
jaxrs properties in Jakarta Rs TCK Test

### DIFF
--- a/org.osgi.test.cases.jakartars/src/org/osgi/test/cases/jakartars/junit/ApplicationLifecyleTestCase.java
+++ b/org.osgi.test.cases.jakartars/src/org/osgi/test/cases/jakartars/junit/ApplicationLifecyleTestCase.java
@@ -346,7 +346,7 @@ public class ApplicationLifecyleTestCase extends AbstractJakartarsTestCase {
 
 		properties.put(
 				JakartarsWhiteboardConstants.JAKARTA_RS_APPLICATION_SELECT,
-				"(osgi.jaxrs.name=test2)");
+				"(osgi.jakartars.name=test2)");
 		resourceReg.setProperties(properties);
 
 		awaitSelection.getValue();
@@ -375,7 +375,7 @@ public class ApplicationLifecyleTestCase extends AbstractJakartarsTestCase {
 
 		properties.put(
 				JakartarsWhiteboardConstants.JAKARTA_RS_APPLICATION_SELECT,
-				"(osgi.jaxrs.name="
+				"(osgi.jakartars.name="
 						+ JakartarsWhiteboardConstants.JAKARTA_RS_DEFAULT_APPLICATION
 						+ ")");
 		resourceReg.setProperties(properties);
@@ -405,7 +405,7 @@ public class ApplicationLifecyleTestCase extends AbstractJakartarsTestCase {
 
 		properties.put(
 				JakartarsWhiteboardConstants.JAKARTA_RS_APPLICATION_SELECT,
-				"(osgi.jaxrs.name=*)");
+				"(osgi.jakartars.name=*)");
 		resourceReg.setProperties(properties);
 
 		awaitSelection.getValue();
@@ -475,7 +475,7 @@ public class ApplicationLifecyleTestCase extends AbstractJakartarsTestCase {
 				Boolean.TRUE);
 		properties.put(
 				JakartarsWhiteboardConstants.JAKARTA_RS_APPLICATION_SELECT,
-				"(osgi.jaxrs.name=*)");
+				"(osgi.jakartars.name=*)");
 
 		awaitSelection = helper.awaitModification(runtime, 5000);
 
@@ -555,7 +555,7 @@ public class ApplicationLifecyleTestCase extends AbstractJakartarsTestCase {
 				Boolean.TRUE);
 		properties.put(
 				JakartarsWhiteboardConstants.JAKARTA_RS_APPLICATION_SELECT,
-				"(osgi.jaxrs.name=*)");
+				"(osgi.jakartars.name=*)");
 
 		awaitSelection = helper.awaitModification(runtime, 5000);
 
@@ -597,7 +597,7 @@ public class ApplicationLifecyleTestCase extends AbstractJakartarsTestCase {
 				Boolean.TRUE);
 		properties.put(
 				JakartarsWhiteboardConstants.JAKARTA_RS_APPLICATION_SELECT,
-				"(osgi.jaxrs.name=t*)");
+				"(osgi.jakartars.name=t*)");
 		context.registerService(WriterInterceptor.class,
 				new StringReplacer("fizz", "fizzbuzz"), properties);
 
@@ -672,7 +672,7 @@ public class ApplicationLifecyleTestCase extends AbstractJakartarsTestCase {
 				Boolean.TRUE);
 		properties.put(
 				JakartarsWhiteboardConstants.JAKARTA_RS_APPLICATION_SELECT,
-				"(osgi.jaxrs.name=*)");
+				"(osgi.jakartars.name=*)");
 
 		awaitSelection = helper.awaitModification(runtime, 5000);
 
@@ -715,7 +715,7 @@ public class ApplicationLifecyleTestCase extends AbstractJakartarsTestCase {
 				Boolean.TRUE);
 		properties.put(
 				JakartarsWhiteboardConstants.JAKARTA_RS_APPLICATION_SELECT,
-				"(osgi.jaxrs.name=*)");
+				"(osgi.jakartars.name=*)");
 		properties.put(JakartarsWhiteboardConstants.JAKARTA_RS_EXTENSION_SELECT,
 				"(replacer-config=*)");
 		context.registerService(WriterInterceptor.class,
@@ -799,7 +799,7 @@ public class ApplicationLifecyleTestCase extends AbstractJakartarsTestCase {
 				Boolean.TRUE);
 		properties.put(
 				JakartarsWhiteboardConstants.JAKARTA_RS_APPLICATION_SELECT,
-				"(osgi.jaxrs.name=*)");
+				"(osgi.jakartars.name=*)");
 
 		awaitSelection = helper.awaitModification(runtime, 5000);
 
@@ -843,7 +843,7 @@ public class ApplicationLifecyleTestCase extends AbstractJakartarsTestCase {
 				Boolean.TRUE);
 		properties.put(
 				JakartarsWhiteboardConstants.JAKARTA_RS_APPLICATION_SELECT,
-				"(osgi.jaxrs.name=*)");
+				"(osgi.jakartars.name=*)");
 		properties.put("replacer-config", "fizz-buzz");
 		context.registerService(ContextResolver.class,
 						new ExtensionConfigProvider("fizz",
@@ -1223,7 +1223,7 @@ public class ApplicationLifecyleTestCase extends AbstractJakartarsTestCase {
 				Boolean.TRUE);
 		properties.put(
 				JakartarsWhiteboardConstants.JAKARTA_RS_APPLICATION_SELECT,
-				"(osgi.jaxrs.name=test)");
+				"(osgi.jakartars.name=test)");
 
 		awaitSelection = helper.awaitModification(runtime, 5000);
 

--- a/org.osgi.test.cases.jakartars/src/org/osgi/test/cases/jakartars/junit/CapabilityTestCase.java
+++ b/org.osgi.test.cases.jakartars/src/org/osgi/test/cases/jakartars/junit/CapabilityTestCase.java
@@ -85,9 +85,10 @@ public class CapabilityTestCase extends AbstractJakartarsTestCase {
 				if (usesDirective != null) {
 					Set<String> packages = new HashSet<String>(Arrays
 							.asList(usesDirective.trim().split("\\s*,\\s*")));
-					uses = packages.contains("org.osgi.service.jaxrs.runtime")
+					uses = packages
+							.contains("org.osgi.service.jakartars.runtime")
 							&& packages.contains(
-									"org.osgi.service.jaxrs.runtime.dto");
+									"org.osgi.service.jakartars.runtime.dto");
 				}
 
 				break;
@@ -133,7 +134,8 @@ public class CapabilityTestCase extends AbstractJakartarsTestCase {
 					Set<String> packages = new HashSet<String>(Arrays
 							.asList(usesDirective.trim().split("\\s*,\\s*")));
 					uses = packages.contains("jakarta.ws.rs.client") &&
-							packages.contains("org.osgi.service.jaxrs.client");
+							packages.contains(
+									"org.osgi.service.jakartars.client");
 				}
 
 				break;
@@ -179,7 +181,8 @@ public class CapabilityTestCase extends AbstractJakartarsTestCase {
 				if (usesDirective != null) {
 					Set<String> packages = new HashSet<String>(Arrays
 							.asList(usesDirective.trim().split("\\s*,\\s*")));
-					uses = packages.contains("org.osgi.service.jaxrs.client");
+					uses = packages
+							.contains("org.osgi.service.jakartars.client");
 				}
 
 				break;
@@ -230,7 +233,7 @@ public class CapabilityTestCase extends AbstractJakartarsTestCase {
 						Collection<String> requiredPackages = new ArrayList<>(
 								JAX_RS_PACKAGES);
 						requiredPackages
-								.add("org.osgi.service.jaxrs.whiteboard");
+								.add("org.osgi.service.jakartars.whiteboard");
 
 						Set<String> packages = new HashSet<String>(
 								Arrays.asList(usesDirective.trim()


### PR DESCRIPTION
Fix old jaxrs property usage instead of jakartars

- changed properties: osg.jaxrs.* -> osgi.jakartars.*
- fixes 6 test issues

Signed-off-by: Mark Hoffmann <m.hoffmann@data-in-motion.biz>