### PR TITLE
ci: Replace use of deprecated set-output

### DIFF
--- a/osgi.tck/build.gradle
+++ b/osgi.tck/build.gradle
@@ -109,7 +109,8 @@ def matrix = tasks.register("matrix") {
 	def tck_matrix = bnd.get("tck-matrix")
 	dependsOn("preptck.core", "preptck.cmpn")
 	doLast {
-		println "::set-output name=tck-matrix::${tck_matrix}"
+		File output = new File(System.getenv("GITHUB_OUTPUT"))
+		output.append("tck-matrix=${tck_matrix}\n", "UTF-8")
 	}
 }
 


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

