### PR TITLE
Need CM compatible implementation update for TCK change 

### DIFF
--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -98,7 +98,7 @@ org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:1.0.8
 org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:1.3.3
 
 jakarta.servlet:jakarta.servlet-api:5.0.0
-org.apache.felix:org.apache.felix.configadmin:1.9.22
+org.apache.felix:org.apache.felix.configadmin:1.9.26
 org.apache.felix:org.apache.felix.configurator:1.0.14
 org.apache.felix:org.apache.felix.cm.json:1.0.6
 org.apache.felix:org.apache.felix.converter:1.0.14

--- a/org.osgi.test.cases.cm/src/org/osgi/test/cases/cm/junit/CMCoordinationTestCase.java
+++ b/org.osgi.test.cases.cm/src/org/osgi/test/cases/cm/junit/CMCoordinationTestCase.java
@@ -436,12 +436,8 @@ public class CMCoordinationTestCase extends DefaultTestBundleControl {
 
 		// wait and verify listener
 		sleep();
-		assertEquals(4, events.size());
+		assertEquals(1, events.size());
 		assertFalse(events.get(0));
-		assertTrue(events.get(1));
-		assertTrue(events.get(2));
-		assertFalse(events.get(3));
-
 	}
 
 	/**
@@ -517,11 +513,7 @@ public class CMCoordinationTestCase extends DefaultTestBundleControl {
 		assertTrue(checkpoint);
 		// wait and verify listener
 		sleep();
-		assertEquals(4, events.size());
+		assertEquals(1, events.size());
 		assertFalse(events.get(0));
-		assertTrue(events.get(1));
-		assertTrue(events.get(2));
-		assertFalse(events.get(3));
-
 	}
 }


### PR DESCRIPTION
Update the Apache Felix Configadmin implementation to 1.9.26.
Adjust coordinator based test cases to new implementation and add new test cases from #498 

This fixes #474 