### PR TITLE
context: Allow BundleContext.getBundle() to work on a stopped context

### DIFF
--- a/org.osgi.framework/src/org/osgi/framework/BundleContext.java
+++ b/org.osgi.framework/src/org/osgi/framework/BundleContext.java
@@ -116,7 +116,6 @@ public interface BundleContext extends BundleReference {
 	 * 
 	 * @return The {@code Bundle} object associated with this
 	 *         {@code BundleContext}.
-	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 */
 	@Override
 	Bundle getBundle();


### PR DESCRIPTION
Fixes https://github.com/osgi/osgi/issues/486
