### PR TITLE
JDBCTestCase fails if driver do not implement all optional methods

### DIFF
--- a/org.osgi.test.cases.jdbc/src/org/osgi/test/cases/jdbc/junit/JDBCTestCase.java
+++ b/org.osgi.test.cases.jdbc/src/org/osgi/test/cases/jdbc/junit/JDBCTestCase.java
@@ -34,9 +34,11 @@ import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.jdbc.DataSourceFactory;
 import org.osgi.test.assertj.servicereference.ServiceReferenceAssert;
+import org.osgi.test.common.annotation.InjectBundleContext;
 import org.osgi.test.common.annotation.InjectService;
 import org.osgi.test.common.service.ServiceAware;
 import org.osgi.test.junit5.service.ServiceSource;
@@ -77,20 +79,21 @@ public class JDBCTestCase {
 	static String				description										= "desc";
 	static String				password										= "pswd";
 	static String				user											= "usr";
-
-	@Test
+	
+	/**
+	 * Test that the JDBS service defines at least one capability
+	 * 
+	 * @param sr the service reference parameter
+	 */
+	@ParameterizedTest
+	@ServiceSource(serviceType = DataSourceFactory.class)
 	public void testMinimumOneDataSourceFactory(
-			@InjectService(cardinality = 1, filter = "("
-					+ OSGI_JDBC_DRIVER_CLASS + "=*)")
-			ServiceAware<DataSourceFactory> sa) {
-		assertThat(sa.getService()).isNotNull();
-
-		ServiceReferenceAssert.assertThat(sa.getServiceReference())
+			ServiceReference<DataSourceFactory> sr) {
+		ServiceReferenceAssert.assertThat(sr)
 				.hasServicePropertiesThat()
 				.containsKey(OSGI_JDBC_CAPABILITY)
 				.extractingByKey(OSGI_JDBC_CAPABILITY)
 				.isNotNull();
-
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
This also includes
- https://github.com/osgi/osgi/pull/531

an fixes https://github.com/osgi/osgi/issues/529

@bjhargrave @stbischof can you please review?

This changes

- always collect all services
- check if the service claims to implement the optional method and assert it creates the expsected items
- if not, assert that it throw the expected SQLExceptions