### PR TITLE
Rework the JDBC TCK

### DIFF
--- a/org.osgi.test.cases.jdbc/src/org/osgi/test/cases/jdbc/junit/JDBCTestCase.java
+++ b/org.osgi.test.cases.jdbc/src/org/osgi/test/cases/jdbc/junit/JDBCTestCase.java
@@ -19,29 +19,46 @@
 package org.osgi.test.cases.jdbc.junit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.osgi.service.jdbc.DataSourceFactory.OSGI_JDBC_CAPABILITY;
 import static org.osgi.service.jdbc.DataSourceFactory.OSGI_JDBC_CAPABILITY_CONNECTIONPOOLDATASOURCE;
 import static org.osgi.service.jdbc.DataSourceFactory.OSGI_JDBC_CAPABILITY_DATASOURCE;
 import static org.osgi.service.jdbc.DataSourceFactory.OSGI_JDBC_CAPABILITY_DRIVER;
 import static org.osgi.service.jdbc.DataSourceFactory.OSGI_JDBC_CAPABILITY_XADATASOURCE;
 import static org.osgi.service.jdbc.DataSourceFactory.OSGI_JDBC_DRIVER_CLASS;
+import static org.osgi.service.jdbc.DataSourceFactory.OSGI_JDBC_DRIVER_NAME;
 import static org.osgi.service.jdbc.DataSourceFactory.OSGI_JDBC_DRIVER_VERSION;
 
+import java.sql.Driver;
 import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Properties;
+import java.util.function.Supplier;
 
-import org.junit.jupiter.api.Test;
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
+import javax.sql.XADataSource;
+
 import org.junit.jupiter.params.ParameterizedTest;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.jdbc.DataSourceFactory;
 import org.osgi.test.assertj.servicereference.ServiceReferenceAssert;
-import org.osgi.test.common.annotation.InjectService;
-import org.osgi.test.common.service.ServiceAware;
+import org.osgi.test.common.annotation.InjectBundleContext;
 import org.osgi.test.junit5.service.ServiceSource;
 
 public class JDBCTestCase {
+	
+	static String				databaseName									= "dbName";
+	static String				dataSourceName									= "dsName";
+	static String				description										= "desc";
+	static String				password										= "pswd";
+	static String				user											= "usr";
+	
 	private static class DfltProps extends Properties {
 
 		private static final long serialVersionUID = 1L;
@@ -57,127 +74,158 @@ public class JDBCTestCase {
 		}
 	}
 
-	private static final String	FILTER_CAPABILITY_CONNECTIONPOOLDATASOURCE	= "("
-			+ OSGI_JDBC_CAPABILITY + "="
-			+ OSGI_JDBC_CAPABILITY_CONNECTIONPOOLDATASOURCE + ")";
+	private static final List<JdbcCapability<?>> ALL_CAPABILITIES = Arrays.asList(
+			new JdbcCapability<Driver>(OSGI_JDBC_CAPABILITY_DRIVER, DataSourceFactory::createDriver, 
+					"org.osgi.service.jdbc.DataSourceFactory.createDriver(Properties)", Properties::new), 
+			new JdbcCapability<DataSource>(OSGI_JDBC_CAPABILITY_DATASOURCE, DataSourceFactory::createDataSource, 
+					"org.osgi.service.jdbc.DataSourceFactory.createDataSource(Properties)", DfltProps::new), 
+			new JdbcCapability<ConnectionPoolDataSource>(OSGI_JDBC_CAPABILITY_CONNECTIONPOOLDATASOURCE, DataSourceFactory::createConnectionPoolDataSource, 
+					"org.osgi.service.jdbc.DataSourceFactory.createConnectionPoolDataSource(Properties)", DfltProps::new), 
+			new JdbcCapability<XADataSource>(OSGI_JDBC_CAPABILITY_XADATASOURCE, DataSourceFactory::createXADataSource, 
+					"org.osgi.service.jdbc.DataSourceFactory.createXADataSource(Properties)", DfltProps::new)
+		);
 
-	private static final String	FILTER_CAPABILITY_DATASOURCE					= "("
-			+ OSGI_JDBC_CAPABILITY + "=" + OSGI_JDBC_CAPABILITY_DATASOURCE
-			+ ")";
-
-	private static final String	FILTER_CAPABILITY_DRIVER						= "("
-			+ OSGI_JDBC_CAPABILITY + "=" + OSGI_JDBC_CAPABILITY_DRIVER + ")";
-
-	private static final String	FILTER_CAPABILITY_XADATASOURCE					= "("
-			+ OSGI_JDBC_CAPABILITY + "=" + OSGI_JDBC_CAPABILITY_XADATASOURCE
-			+ ")";
-
-	static String				databaseName									= "dbName";
-	static String				dataSourceName									= "dsName";
-	static String				description										= "desc";
-	static String				password										= "pswd";
-	static String				user											= "usr";
-
-	@Test
-	public void testMinimumOneDataSourceFactory(
-			@InjectService(cardinality = 1, filter = "("
-					+ OSGI_JDBC_DRIVER_CLASS + "=*)")
-			ServiceAware<DataSourceFactory> sa) {
-		assertThat(sa.getService()).isNotNull();
-
-		ServiceReferenceAssert.assertThat(sa.getServiceReference())
-				.hasServicePropertiesThat()
-				.containsKey(OSGI_JDBC_CAPABILITY)
-				.extractingByKey(OSGI_JDBC_CAPABILITY)
-				.isNotNull();
-
-	}
-
+	@InjectBundleContext
+	BundleContext bundleContext;
+	
+	/**
+	 * This test that 
+	 * <ul>
+	 * <li>all required properties are declared and of the required type</li>
+	 * <li>all optional properties are of the required type</li>
+	 * </ul>
+	 * @param sr the service reference of the {@link DataSourceFactory}
+	 */
 	@ParameterizedTest
 	@ServiceSource(serviceType = DataSourceFactory.class)
-	public void testRegisteredProperties(
-			ServiceReference<DataSourceFactory> sr) {
+	public void testRegisteredProperties(ServiceReference<DataSourceFactory> sr) {
 
 		ServiceReferenceAssert<DataSourceFactory> sRefAssert = ServiceReferenceAssert
 				.assertThat(sr);
 
+		//first check all mandatory properties
 		sRefAssert.hasServicePropertiesThat()
-				.as("The DataSourceFactory is missing the required osgi.jdbc.driver.class property")
+				.as("According to '125.2 Database Driver' the DataSourceFactory must specify the '%s' with its registration.",
+						OSGI_JDBC_DRIVER_CLASS)
 				.containsKey(OSGI_JDBC_DRIVER_CLASS)
 				.extractingByKey(OSGI_JDBC_DRIVER_CLASS)
 				.isNotNull()
-				.as("The DataSourceFactory driver class is not a String")
+				.as("According to '125.2 Database Driver' the property '%s' must be a String", OSGI_JDBC_DRIVER_CLASS)
 				.isInstanceOf(String.class);
+		
+		sRefAssert.hasServicePropertiesThat()
+				.as(String.format("According to '125.2 Database Driver' the DataSourceFactory must specify the '%s' with its registration.",
+						OSGI_JDBC_CAPABILITY))
+				.containsKey(OSGI_JDBC_CAPABILITY)
+				.extractingByKey(OSGI_JDBC_CAPABILITY)
+				.isNotNull()
+				.as("According to '125.2 Database Driver' the property '%s' must be a String+", OSGI_JDBC_CAPABILITY)
+				.isInstanceOfAny(String.class, String[].class, Collection.class);
 
+		//then check optional ones
 		Object driverVersion = sr.getProperty(OSGI_JDBC_DRIVER_VERSION);
-
 		if (driverVersion != null) {
-			assertTrue(driverVersion instanceof String,
-					"The DataSourceFactory driver version is not a String");
+			assertThat(driverVersion)
+				.as("According to '125.2 Database Driver' the property '%s' must be a String if specified", OSGI_JDBC_DRIVER_VERSION)
+				.isInstanceOf(String.class);
+		}
+		Object driverName = sr.getProperty(OSGI_JDBC_DRIVER_NAME);
+		if (driverName != null) {
+			assertThat(driverName)
+				.as("According to '125.2 Database Driver' the property '%s' must be a String if specified", OSGI_JDBC_DRIVER_NAME)
+				.isInstanceOf(String.class);
+		}
+		
+	}
+
+	/**
+	 * This test that 
+	 * <ul>
+	 * <li>all declared capabilities behave according to their contract</li>
+	 * <li>at least one capability is provided</li>
+	 * </ul>
+	 * @param sr the service reference of the {@link DataSourceFactory}
+	 */
+	@ParameterizedTest
+	@ServiceSource(serviceType = DataSourceFactory.class)
+	public void testDeclaredCapabilities(ServiceReference<DataSourceFactory> sr)
+			throws SQLException, InvalidSyntaxException {
+		boolean providesAny = false;
+		for (JdbcCapability<?> capability : ALL_CAPABILITIES) {
+			providesAny |= testCapability(sr, capability);
+		}
+		assertThat(providesAny)
+			.as("According to '125.2 Database Driver' the DataSourceFactory must at laest provide one of the follwoing capabilities '%s'.", ALL_CAPABILITIES)
+			.isTrue();
+	}
+
+	private <T> boolean testCapability(ServiceReference<DataSourceFactory> reference, JdbcCapability<T> capability) throws SQLException, InvalidSyntaxException {
+		DataSourceFactory dsf = bundleContext.getService(reference);
+		try {
+			if (bundleContext.createFilter(String.format("(%s=%s)", OSGI_JDBC_CAPABILITY, capability.capability)).match(reference)) {
+				//if the source declares the support, it should work to create items without an exception
+				assertThatNoException()
+					.as("According to '125.2 Database Driver' a DataSourceFactory declaring the capability %s must not throw any exception when invoking %s with a null argument",
+							capability.capability, capability.functionName)
+					.isThrownBy(() -> capability.apply(dsf, null));
+				assertThat(capability.apply(dsf, null))
+					.as("According to '125.2 Database Driver' a DataSourceFactory declaring the capability %s must not return null when invoking %s with a null argument",
+						capability.capability, capability.functionName)
+					.isNotNull();
+				assertThatNoException()
+					.as("According to '125.2 Database Driver' a DataSourceFactory declaring the capability %s must not throw any exception when invoking %s with a properties object containing the properties %s",
+						capability.capability, capability.functionName, capability.standardPropertiesProvider.get())
+					.isThrownBy(() -> capability.apply(dsf, capability.standardPropertiesProvider.get()));
+				assertThat(capability.apply(dsf, capability.standardPropertiesProvider.get()))
+					.as("According to '125.2 Database Driver' a DataSourceFactory declaring the capability %s must not return null when invoking %s with a properties object containing the properties %s",
+						capability.capability, capability.functionName, capability.standardPropertiesProvider.get())
+					.isNotNull();
+				return true;
+			} else {
+				//it is required to throw an exception here
+				assertThatExceptionOfType(SQLException.class)
+					.as("According to '125.2 Database Driver' a DataSourceFactory not declaring the capability %s must throw SQLException when invoking %s with a null argument",
+							capability.capability, capability.functionName)
+					.isThrownBy(() -> capability.apply(dsf, null));
+				assertThatExceptionOfType(SQLException.class)
+					.as("According to '125.2 Database Driver' a DataSourceFactory not declaring the capability %s must throw SQLException when invoking %s a properties object containing the properties %s",
+						capability.capability, capability.functionName, capability.standardPropertiesProvider.get())
+					.isThrownBy(() -> capability.apply(dsf, capability.standardPropertiesProvider.get()));
+				return false;
+			}
+		} finally {
+			if (dsf != null) {
+				bundleContext.ungetService(reference);
+			}
 		}
 	}
-
-	@ParameterizedTest
-	@ServiceSource(serviceType = DataSourceFactory.class, filter = FILTER_CAPABILITY_CONNECTIONPOOLDATASOURCE)
-	public void testCapabilityConnectionPoolDataSource(DataSourceFactory dsf)
-			throws SQLException {
-
-		assertThatNoException()
-				.isThrownBy(() -> dsf.createConnectionPoolDataSource(null));
-
-		assertThat(dsf.createConnectionPoolDataSource(null)).isNotNull();
-
-		assertThatNoException().isThrownBy(
-				() -> dsf.createConnectionPoolDataSource(new DfltProps()));
-
-		assertThat(dsf.createConnectionPoolDataSource(new DfltProps()))
-				.isNotNull();
+	
+	private static interface DsfCallback<T, U, R> {
+		R invoke(T t, U u) throws SQLException;
 	}
 
-	@ParameterizedTest
-	@ServiceSource(serviceType = DataSourceFactory.class, filter = FILTER_CAPABILITY_DATASOURCE)
-	public void testCapabilityDataSource(DataSourceFactory dsf)
-			throws SQLException {
+	private static final class JdbcCapability<T> {
 
-		assertThatNoException().isThrownBy(() -> dsf.createDataSource(null));
+		private String capability;
+		private DsfCallback<DataSourceFactory, Properties, T> accessorFunction;
+		private String functionName;
+		private Supplier<Properties> standardPropertiesProvider;
 
-		assertThat(dsf.createDataSource(null)).isNotNull();
-
-		assertThatNoException()
-				.isThrownBy(() -> dsf.createDataSource(new DfltProps()));
-
-		assertThat(dsf.createDataSource(new DfltProps())).isNotNull();
+		public JdbcCapability(String capability, DsfCallback<DataSourceFactory, Properties, T> accessorFunction, String functionName, Supplier<Properties> standardPropertiesProvider) {
+			this.capability = capability;
+			this.accessorFunction = accessorFunction;
+			this.functionName = functionName;
+			this.standardPropertiesProvider = standardPropertiesProvider;
+		}
+		
+		@Override
+		public String toString() {
+			return capability;
+		}
+		
+		T apply(DataSourceFactory factory, Properties properties) throws SQLException {
+			return accessorFunction.invoke(factory, properties);
+		}
+		
 	}
-
-	@ParameterizedTest
-	@ServiceSource(serviceType = DataSourceFactory.class, filter = FILTER_CAPABILITY_DRIVER)
-	public void testCapabilityDriver(DataSourceFactory dsf)
-			throws SQLException {
-
-		assertThatNoException().isThrownBy(() -> dsf.createDriver(null));
-
-		assertThat(dsf.createDriver(null)).isNotNull();
-
-		assertThatNoException()
-				.isThrownBy(() -> dsf.createDriver(new Properties()));
-
-		assertThat(dsf.createDriver(new Properties())).isNotNull();
-
-	}
-
-	@ParameterizedTest
-	@ServiceSource(serviceType = DataSourceFactory.class, filter = FILTER_CAPABILITY_XADATASOURCE)
-	public void testCapabilityXADataSource(DataSourceFactory dsf)
-			throws SQLException {
-
-		assertThatNoException().isThrownBy(() -> dsf.createXADataSource(null));
-
-		assertThat(dsf.createXADataSource(null)).isNotNull();
-
-		assertThatNoException()
-				.isThrownBy(() -> dsf.createXADataSource(new DfltProps()));
-
-		assertThat(dsf.createXADataSource(new DfltProps())).isNotNull();
-	}
-
 }


### PR DESCRIPTION
This do the following:
- merge the method testRegisteredProperties / testMinimumOneDataSourceFactory as it is not compliant to only test there is one valid DSF but all need to implement all required properties
- check that the description (if given) is a string property
- check that the capability is either a string or a String[] type
- join the individual testCapabilityX into one method as actually one needs to check all declared capabilities of one source fulfills the overall contract of at least provide one.

Fix https://github.com/osgi/osgi/issues/529
Fix https://github.com/osgi/osgi/issues/530

@bjhargrave @stbischof please have a look. This should now be consistent to the spec and could test any number of DSF registered.

Additionally this now also check that a DSF at least implements one of the valid values (in contrast to before where it was only checked that one DSF declares any value) and also checks that the property if of the desired type `String+`