### PR TITLE
core: Make InvalidSyntaxException a runtime exception

### DIFF
--- a/cnf/repo/org.osgi.impl.framework/org.osgi.impl.framework-9.0.0.lib
+++ b/cnf/repo/org.osgi.impl.framework/org.osgi.impl.framework-9.0.0.lib
@@ -1,3 +1,5 @@
+# Temporarily need to use latest framework packages
+org.osgi.framework;version=latest
 # Temporarily need to use latest resource packages
 org.osgi.resource;version=latest
 org.eclipse.osgi;version=3.18

--- a/org.osgi.framework/src/org/osgi/framework/BundleContext.java
+++ b/org.osgi.framework/src/org/osgi/framework/BundleContext.java
@@ -276,7 +276,7 @@ public interface BundleContext extends BundleReference {
 	 * @see ServiceListener
 	 * @see ServicePermission
 	 */
-	void addServiceListener(ServiceListener listener, String filter) throws InvalidSyntaxException;
+	void addServiceListener(ServiceListener listener, String filter);
 
 	/**
 	 * Adds the specified {@code ServiceListener} object to the context bundle's
@@ -573,7 +573,7 @@ public interface BundleContext extends BundleReference {
 	 *             an invalid filter expression that cannot be parsed.
 	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 */
-	ServiceReference<?>[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException;
+	ServiceReference< ? >[] getServiceReferences(String clazz, String filter);
 
 	/**
 	 * Returns an array of {@code ServiceReference} objects. The returned array
@@ -621,7 +621,8 @@ public interface BundleContext extends BundleReference {
 	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 * @since 1.3
 	 */
-	ServiceReference<?>[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException;
+	ServiceReference< ? >[] getAllServiceReferences(String clazz,
+			String filter);
 
 	/**
 	 * Returns a {@code ServiceReference} object for a service that implements
@@ -727,7 +728,8 @@ public interface BundleContext extends BundleReference {
 	 * @throws IllegalStateException If this BundleContext is no longer valid.
 	 * @since 1.6
 	 */
-	<S> Collection<ServiceReference<S>> getServiceReferences(Class<S> clazz, String filter) throws InvalidSyntaxException;
+	<S> Collection<ServiceReference<S>> getServiceReferences(Class<S> clazz,
+			String filter);
 
 	/**
 	 * Returns the service object for the service referenced by the specified
@@ -916,7 +918,7 @@ public interface BundleContext extends BundleReference {
 	 * @see FrameworkUtil#createFilter(String)
 	 * @since 1.1
 	 */
-	Filter createFilter(String filter) throws InvalidSyntaxException;
+	Filter createFilter(String filter);
 
 	/**
 	 * Returns the bundle with the specified location.

--- a/org.osgi.framework/src/org/osgi/framework/FilterImpl.java
+++ b/org.osgi.framework/src/org/osgi/framework/FilterImpl.java
@@ -166,8 +166,7 @@ abstract class FilterImpl implements Filter {
 	 * @throws InvalidSyntaxException If the filter parameter contains an
 	 *             invalid filter string that cannot be parsed.
 	 */
-	static FilterImpl createFilter(String filterString)
-			throws InvalidSyntaxException {
+	static FilterImpl createFilter(String filterString) {
 		return new Parser(filterString).parse();
 	}
 
@@ -968,7 +967,7 @@ abstract class FilterImpl implements Filter {
 			pos = 0;
 		}
 
-		FilterImpl parse() throws InvalidSyntaxException {
+		FilterImpl parse() {
 			FilterImpl filter;
 			try {
 				filter = parse_filter();
@@ -986,7 +985,7 @@ abstract class FilterImpl implements Filter {
 			return filter;
 		}
 
-		private FilterImpl parse_filter() throws InvalidSyntaxException {
+		private FilterImpl parse_filter() {
 			FilterImpl filter;
 			skipWhiteSpace();
 
@@ -1015,7 +1014,7 @@ abstract class FilterImpl implements Filter {
 			return filter;
 		}
 
-		private FilterImpl parse_filtercomp() throws InvalidSyntaxException {
+		private FilterImpl parse_filtercomp() {
 			skipWhiteSpace();
 
 			char c = filterChars[pos];
@@ -1037,7 +1036,7 @@ abstract class FilterImpl implements Filter {
 			return parse_item();
 		}
 
-		private FilterImpl parse_and() throws InvalidSyntaxException {
+		private FilterImpl parse_and() {
 			int lookahead = pos;
 			skipWhiteSpace();
 
@@ -1056,7 +1055,7 @@ abstract class FilterImpl implements Filter {
 			return new FilterImpl.And(operands.toArray(new FilterImpl[0]));
 		}
 
-		private FilterImpl parse_or() throws InvalidSyntaxException {
+		private FilterImpl parse_or() {
 			int lookahead = pos;
 			skipWhiteSpace();
 
@@ -1075,7 +1074,7 @@ abstract class FilterImpl implements Filter {
 			return new FilterImpl.Or(operands.toArray(new FilterImpl[0]));
 		}
 
-		private FilterImpl parse_not() throws InvalidSyntaxException {
+		private FilterImpl parse_not() {
 			int lookahead = pos;
 			skipWhiteSpace();
 
@@ -1089,7 +1088,7 @@ abstract class FilterImpl implements Filter {
 			return new FilterImpl.Not(child);
 		}
 
-		private FilterImpl parse_item() throws InvalidSyntaxException {
+		private FilterImpl parse_item() {
 			String attr = parse_attr();
 
 			skipWhiteSpace();
@@ -1149,7 +1148,7 @@ abstract class FilterImpl implements Filter {
 					filterstring);
 		}
 
-		private String parse_attr() throws InvalidSyntaxException {
+		private String parse_attr() {
 			skipWhiteSpace();
 
 			int begin = pos;
@@ -1179,7 +1178,7 @@ abstract class FilterImpl implements Filter {
 			return new String(filterChars, begin, length);
 		}
 
-		private String parse_value() throws InvalidSyntaxException {
+		private String parse_value() {
 			StringBuilder sb = new StringBuilder(filterChars.length - pos);
 
 			parseloop: while (true) {
@@ -1219,7 +1218,7 @@ abstract class FilterImpl implements Filter {
 			return sb.toString();
 		}
 
-		private String[] parse_substring() throws InvalidSyntaxException {
+		private String[] parse_substring() {
 			StringBuilder sb = new StringBuilder(filterChars.length - pos);
 
 			List<String> operands = new ArrayList<>(10);

--- a/org.osgi.framework/src/org/osgi/framework/FrameworkUtil.java
+++ b/org.osgi.framework/src/org/osgi/framework/FrameworkUtil.java
@@ -81,7 +81,7 @@ public class FrameworkUtil {
 	 * 
 	 * @see Filter
 	 */
-	public static Filter createFilter(String filter) throws InvalidSyntaxException {
+	public static Filter createFilter(String filter) {
 		return FilterImpl.createFilter(filter);
 	}
 

--- a/org.osgi.framework/src/org/osgi/framework/InvalidSyntaxException.java
+++ b/org.osgi.framework/src/org/osgi/framework/InvalidSyntaxException.java
@@ -33,7 +33,7 @@ package org.osgi.framework;
  * @author $Id$
  */
 
-public class InvalidSyntaxException extends Exception {
+public class InvalidSyntaxException extends RuntimeException {
 	static final long		serialVersionUID	= -4295194420816491875L;
 	/**
 	 * The invalid filter string.

--- a/org.osgi.test.cases.framework.launch/src/org/osgi/test/cases/framework/launch/extensions/tb1/Activator.java
+++ b/org.osgi.test.cases.framework.launch/src/org/osgi/test/cases/framework/launch/extensions/tb1/Activator.java
@@ -36,7 +36,6 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
-import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.framework.startlevel.FrameworkStartLevel;
@@ -182,8 +181,8 @@ public class Activator implements BundleActivator {
 				"REGISTER_SERVICE", getServiceProps("REGISTER_SERVICE")));
 	}
 
-	private void testTrueCondition(List<String> results, BundleContext context)
-			throws InvalidSyntaxException {
+	private void testTrueCondition(List<String> results,
+			BundleContext context) {
 		ServiceReference<Condition> conditionRef = context
 				.getServiceReferences(Condition.class,
 						'(' + Condition.CONDITION_ID + '='

--- a/org.osgi.test.cases.framework/src/org/osgi/test/cases/framework/junit/filter/BundleContextFilterTests.java
+++ b/org.osgi.test.cases.framework/src/org/osgi/test/cases/framework/junit/filter/BundleContextFilterTests.java
@@ -18,12 +18,19 @@
 
 package org.osgi.test.cases.framework.junit.filter;
 
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.Filter;
-import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.test.common.annotation.InjectBundleContext;
+import org.osgi.test.junit5.context.BundleContextExtension;
 
+@ExtendWith(BundleContextExtension.class)
 public class BundleContextFilterTests extends AbstractFilterTests {
-	public Filter createFilter(String filterString)
-			throws InvalidSyntaxException {
-		return getContext().createFilter(filterString);
+	@InjectBundleContext
+	BundleContext context;
+
+	@Override
+	public Filter createFilter(String filterString) {
+		return context.createFilter(filterString);
 	}
 }

--- a/org.osgi.test.cases.framework/src/org/osgi/test/cases/framework/junit/frameworkutil/FrameworkUtilFilterTests.java
+++ b/org.osgi.test.cases.framework/src/org/osgi/test/cases/framework/junit/frameworkutil/FrameworkUtilFilterTests.java
@@ -20,12 +20,11 @@ package org.osgi.test.cases.framework.junit.frameworkutil;
 
 import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.test.cases.framework.junit.filter.AbstractFilterTests;
 
 public class FrameworkUtilFilterTests extends AbstractFilterTests {
-	public Filter createFilter(String filterString)
-			throws InvalidSyntaxException {
+	@Override
+	public Filter createFilter(String filterString) {
 		return FrameworkUtil.createFilter(filterString);
 	}
 }


### PR DESCRIPTION
This is binary compatible since we are just introducing a new super type whose super type is the previous super type.

We also remove "throws InvalidSyntaxException" from the framework API since it is OSGi policy to not declare runtime exceptions in the throws clause of a method's declaration. We still javadoc the throwing of the exception.

Filter tests are updated to JUnit 5 and osgi-test.

Fixes https://github.com/osgi/osgi/issues/546
