### PR TITLE
Remove dependency on bcel by directly rewriting class bytes

### DIFF
--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -174,8 +174,6 @@ log4j:log4j:1.2.15
 
 com.h2database:h2:1.4.193
 
-org.apache.servicemix.bundles:org.apache.servicemix.bundles.bcel:5.2_4
-
 org.easymock:easymock:2.5.1
 
 org.springframework:spring-aop:3.1.0.RELEASE

--- a/licensed/LICENSE.TXT
+++ b/licensed/LICENSE.TXT
@@ -26,22 +26,6 @@ License					http://saxon.sourceforge.net/saxon6.5.4/conditions.html
 URL						http://prdownloads.sourceforge.net/saxon/saxon6-5-4.zip
 Modifications			NONE, library used as is
 
-BCEL--------------------------------------------------------------------
-Copyright				1999,2005 Apache Software Foundation
-Used					In OSGi jar2xml (org.osgi.tools) to create an XML file from a JAR
-File					bcel.jar
-License					licenses/ASL-1.1.txt
-URL						http://jakarta.apache.org/bcel/
-Modifications			NONE, library used as is
-
-BCEL--------------------------------------------------------------------
-Copyright				Apache Software Foundation
-Used					In weaving compliance tests
-File					org.apache.servicemix.bundles.bcel
-License					licenses/ASL-2.0.txt
-URL                     http://mirrors.ibiblio.org/pub/mirrors/maven2/org/apache/servicemix/bundles/org.apache.servicemix.bundles.bcel/5.2_3/org.apache.servicemix.bundles.bcel-5.2_3.jar
-Modifications			NONE, library used as is
-
 JUNIT-------------------------------------------------------------------
 Copyright				Packaged by SpringSource, adds no copyright, or
 Used					Diverse JUNIT tests, the JUNIT perspective seems

--- a/org.osgi.test.cases.framework/bnd.bnd
+++ b/org.osgi.test.cases.framework/bnd.bnd
@@ -288,8 +288,7 @@ Bundle-ClassPath: .,div.tb6.jar
     org.osgi.test.support;version=project, \
 	org.osgi.dto;maven-scope=provided;version=latest, \
 	org.osgi.resource;maven-scope=provided;version=latest, \
-	org.osgi.framework;maven-scope=provided;version=latest, \
-	org.apache.servicemix.bundles.bcel;version=5.2
+	org.osgi.framework;maven-scope=provided;version=latest
 
 -signaturetest                      = \
     org.osgi.dto, \

--- a/org.osgi.test.cases.framework/bnd.bnd
+++ b/org.osgi.test.cases.framework/bnd.bnd
@@ -306,8 +306,7 @@ Bundle-ClassPath: .,div.tb6.jar
     org.osgi.framework.wiring, \
     org.osgi.framework.wiring.dto
 
--runbundles = \
-	org.apache.servicemix.bundles.bcel;version=5.2 
+-runbundles = 
 
 -runproperties = ${runproperties}, \
 	${p}.div.tb12=abc, \

--- a/org.osgi.test.cases.framework/src/org/osgi/test/cases/framework/weaving/tb1/TestClass.java
+++ b/org.osgi.test.cases.framework/src/org/osgi/test/cases/framework/weaving/tb1/TestClass.java
@@ -27,6 +27,7 @@ package org.osgi.test.cases.framework.weaving.tb1;
 public class TestClass {
 
 	public String toString() {
-		return "DEFAULT";
+		return "f31aa0ab-f572-4c3a-b564-4e47f5935603_a5d56cb7-8987-416e-9212-26631f2924cd"
+				.trim();
 	}
 }

--- a/org.osgi.test.cases.framework/src/org/osgi/test/cases/framework/weaving/tb1/TestDynamicImport.java
+++ b/org.osgi.test.cases.framework/src/org/osgi/test/cases/framework/weaving/tb1/TestDynamicImport.java
@@ -32,7 +32,8 @@ public class TestDynamicImport {
 	 * N.B. without weaving this method will throw {@link ClassNotFoundException}
 	 */
 	public String toString() {
-		return doDynamicImport("DEFAULT");
+		return doDynamicImport(
+				"f31aa0ab-f572-4c3a-b564-4e47f5935603_a5d56cb7-8987-416e-9212-26631f2924cd");
 	}
 
 	/**
@@ -42,6 +43,8 @@ public class TestDynamicImport {
 	 * @return
 	 */
 	private String doDynamicImport(String name) {
+		// Trim any added spaces
+		name = name.trim();
 		try {
 			//If the class name is the SymbolicNameVersion class then we want the object's
 			//toString, otherwise the Class's toString is fine, and allows us to load interfaces

--- a/osgi.tck/layout.bnd
+++ b/osgi.tck/layout.bnd
@@ -8,7 +8,6 @@ osgi.cmpn.api: ${sort;${filterout;${projectswhere;packaging;*cmpn*};(org\\.osgi\
 
 jar.core.tests: \
     ${osgi.core.api},\
-    org.apache.servicemix.bundles.bcel,\
     org.osgi.impl.service.cm,\
     osgi.tck.junit-platform
 


### PR DESCRIPTION
The test weaving is sufficiently simple that we can simply search for a series of bytes in the class file and directly replace them.

Fixes #563