### PR TITLE
Hash pin GitHub Actions

### DIFF
--- a/.github/workflows/bnd-test.yml
+++ b/.github/workflows/bnd-test.yml
@@ -53,21 +53,21 @@ jobs:
     if: ${{ github.repository == 'osgi/osgi' }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     - name: Set up Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
       with:
         distribution: 'temurin'
         java-version: ${{ env.java_version }}
     - name: Build
       id: build
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@40b6781dcdec2762ad36556682ac74e31030cfe2 # v2.5.1
       with:
         cache-read-only: ${{ github.ref != 'refs/heads/main' }}
         arguments: --continue :buildscriptDependencies :build :osgi.specs:specifications :osgi.tck:tck.core
     - name: Upload TCK Test Reports on failure
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: TCK-core-reports
         path: |

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -59,25 +59,25 @@ jobs:
       tck-matrix: ${{ steps.build.outputs.tck-matrix }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     - name: Git Unshallow
       if: ${{ fromJSON(env.canonical) }}
       run: |
         git fetch --prune --unshallow
         git describe --dirty --always --abbrev=9
     - name: Set up Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
       with:
         distribution: 'temurin'
         java-version: ${{ env.java_version }}
     - name: Build
       id: build
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@40b6781dcdec2762ad36556682ac74e31030cfe2 # v2.5.1
       with:
         cache-read-only: ${{ github.ref != 'refs/heads/main' }}
         arguments: --continue :buildscriptDependencies :build
     - name: Upload TCK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: OSGi-TCK
         if-no-files-found: error
@@ -86,7 +86,7 @@ jobs:
           !osgi.tck/generated/osgi.tck.*.jar
     - name: Configure settings.xml for Publish
       if: ${{ fromJSON(env.canonical) }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
       with:
         distribution: 'temurin'
         java-version: ${{ env.java_version }}
@@ -105,7 +105,7 @@ jobs:
     - name: Publish
       id: publish
       if: ${{ fromJSON(env.canonical) }}
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@40b6781dcdec2762ad36556682ac74e31030cfe2 # v2.5.1
       with:
         cache-read-only: ${{ github.ref != 'refs/heads/main' }}
         arguments: :publish
@@ -116,7 +116,7 @@ jobs:
         OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
     - name: Upload Generated Repo
       if: ${{ fromJSON(env.canonical) }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: OSGi-Generated-Repo
         path: |
@@ -127,27 +127,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     - name: Set up Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
       with:
         distribution: 'temurin'
         java-version: ${{ env.java_version }}
     - name: Build
       id: build
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@40b6781dcdec2762ad36556682ac74e31030cfe2 # v2.5.1
       with:
         cache-read-only: ${{ github.ref != 'refs/heads/main' }}
         arguments: --continue :osgi.specs:specifications
     - name: Upload Specification HTML
       if: ${{ fromJSON(env.canonical) || ((github.repository != 'osgi/osgi') && (github.event_name != 'pull_request')) }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: OSGi-Specification-HTML
         path: osgi.specs/generated/html/
     - name: Upload Specification PDF
       if: ${{ fromJSON(env.canonical) }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: OSGi-Specification-PDF
         path: osgi.specs/generated/*.pdf
@@ -161,12 +161,12 @@ jobs:
       contents: write
     steps:
     - name: Download Specification HTML
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: OSGi-Specification-HTML
         path: osgi.specs/generated/html
     - name: Publish Specification HTML
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
@@ -184,12 +184,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
       with:
         distribution: 'temurin'
         java-version: ${{ env.java_version }}
     - name: Download TCK
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: OSGi-TCK
     - name: Run TCK
@@ -199,7 +199,7 @@ jobs:
         java -jar jar/bnd.jar --exceptions runtests --title ${{ matrix.tck }} --reportdir reports/${{ matrix.tck }} ${{ matrix.tck }}.bnd
     - name: Upload TCK Test Reports
       if: ${{ always() && ((steps.tck.outcome == 'success') || (steps.tck.outcome == 'failure')) }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: TCK-${{ matrix.tck }}-reports
         path: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
     - name: Stale Action
-      uses: actions/stale@v8
+      uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
       with:
         days-before-stale: 365
         days-before-close: 21

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -50,4 +50,4 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     - name: Gradle Wrapper Validation
-      uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6 # v1.0.5
+      uses: gradle/wrapper-validation-action@8d49e559aae34d3e0eb16cde532684bc9702762b # v1.0.6

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -48,6 +48,6 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     - name: Gradle Wrapper Validation
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6 # v1.0.5


### PR DESCRIPTION
Closes #592 

### Changes

- I've hash pin GitHub Actions by using step security to help on identifying the right hash commit. 