### PR TITLE
Fix missing wait in the Application Lifecycle tests

### DIFF
--- a/org.osgi.test.cases.jakartars/src/org/osgi/test/cases/jakartars/junit/ApplicationLifecyleTestCase.java
+++ b/org.osgi.test.cases.jakartars/src/org/osgi/test/cases/jakartars/junit/ApplicationLifecyleTestCase.java
@@ -258,6 +258,8 @@ public class ApplicationLifecyleTestCase extends AbstractJakartarsTestCase {
 				"changed");
 		reg.setProperties(properties);
 
+		awaitSelection.getValue();
+
 		httpResponse = client.execute(RequestBuilder
 				.get(baseURI + "changed/annotated/whiteboard/resource")
 				.build());


### PR DESCRIPTION
The Jakarta REST Whiteboard is not required to synchronously update when a service is registered, but instead uses a change count to indicate that a change has been made. The ApplicationPath test set up a Promise to wait for this, but it was never actually used, causing intermittent failures with asynchronous updates.