### PR TITLE
Fix test failures with asynchronous implementations

### DIFF
--- a/org.osgi.test.cases.jakartars/src/org/osgi/test/cases/jakartars/junit/AbstractJakartarsTestCase.java
+++ b/org.osgi.test.cases.jakartars/src/org/osgi/test/cases/jakartars/junit/AbstractJakartarsTestCase.java
@@ -45,6 +45,7 @@ import org.osgi.service.jakartars.runtime.JakartarsServiceRuntime;
 import org.osgi.test.cases.jakartars.util.ServiceUpdateHelper;
 import org.osgi.test.common.annotation.InjectBundleContext;
 import org.osgi.test.junit5.context.BundleContextExtension;
+import org.osgi.util.promise.Promises;
 
 /**
  * This test covers the lifecycle behaviours described in section 151.4.2
@@ -69,6 +70,16 @@ public abstract class AbstractJakartarsTestCase {
 		helper.open();
 
 		runtime = helper.awaitRuntime(5000);
+		try {
+			while (helper.awaitModification(runtime, 200)
+					.map(x -> Boolean.TRUE)
+					.fallbackTo(Promises.resolved(Boolean.FALSE))
+					.getValue())
+				;
+		} catch (Exception e) {
+			throw new IllegalStateException(
+					"Failed while waiting for the whiteboard to settle before the test");
+		}
 	}
 
 	@AfterEach


### PR DESCRIPTION
The Jakarta REST Whiteboard is not required to synchronously update when a service is registered, but instead uses a change count to indicate that a change has been made. The test suites assume that the whiteboard will be in a clean and stable state when they start, but this is not the case when the whiteboard updates asynchronously. Specifically the services registered in tests are unregistered at the end of those tests and then the next test starts immediately. The result of this is that the whiteboard may still be processing the service removals during the start of the next test, this in turn messes up the change counting for the next test and causes failures.

This change adds a loop at the end of each test which waits until the whiteboard change count remains stable for a short (200ms) period.