### PR TITLE
Fix missing wait in the Extension Name Binding tests

### DIFF
--- a/org.osgi.test.cases.jakartars/src/org/osgi/test/cases/jakartars/junit/ExtensionLifecyleTestCase.java
+++ b/org.osgi.test.cases.jakartars/src/org/osgi/test/cases/jakartars/junit/ExtensionLifecyleTestCase.java
@@ -161,6 +161,8 @@ public class ExtensionLifecyleTestCase extends AbstractJakartarsTestCase {
 		context.registerService(WriterInterceptor.class,
 				new BoundStringReplacer("fizz", "fizzbuzz"), properties);
 
+		awaitSelection.getValue();
+
 		String baseURI = getBaseURI();
 
 		// One method should be intercepted but not the other


### PR DESCRIPTION
The Jakarta REST Whiteboard is not required to synchronously update when a service is registered, but instead uses a change count to indicate that a change has been made. The Extesnsion Name Binding test set up a Promise to wait for this, but it was never actually used, causing intermittent failures with asynchronous updates.