### PR TITLE
Fix NPE in JPAService_1_1_TestCase

### DIFF
--- a/org.osgi.test.cases.jpa/src/org/osgi/test/cases/jpa/junit/JPAService_1_1_TestCase.java
+++ b/org.osgi.test.cases.jpa/src/org/osgi/test/cases/jpa/junit/JPAService_1_1_TestCase.java
@@ -242,6 +242,9 @@ public class JPAService_1_1_TestCase extends DefaultTestBundleControl {
 			assertEquals(provider, emfBuilder.getPersistenceProviderName());
 
 			Bundle providerBundle = emfBuilder.getPersistenceProviderBundle();
+			assertNotNull(
+					"EntityManagerFactoryBuilder returned null for PersistenceProviderBundle",
+					providerBundle);
 
 			boolean found = false;
 			for (ServiceReference< ? > ref : providerBundle


### PR DESCRIPTION
The test JPAService_1_1_TestCase#testReportsCorrectPersistenceProviderDetails can run into a NPE as it accesses the providerBundle without a null assertion.

Can be seen in this tck run: https://github.com/ops4j/org.ops4j.pax.jpa/runs/27083276801