### PR TITLE
Fix jpa test to properly cleanup in case of failures

### DIFF
--- a/org.osgi.test.cases.jpa/src/org/osgi/test/cases/jpa/junit/JPAService_1_1_TestCase.java
+++ b/org.osgi.test.cases.jpa/src/org/osgi/test/cases/jpa/junit/JPAService_1_1_TestCase.java
@@ -53,8 +53,8 @@ public class JPAService_1_1_TestCase extends DefaultTestBundleControl {
 		Bundle persistenceBundle = installBundle("emfBuilderBundle.jar");
 		EntityManagerFactoryBuilder emfBuilder = null;
 		EntityManagerFactory emf = null;
-		waitForService(EntityManagerFactoryBuilder.class, true);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class, true);
 			emfBuilder = getService(EntityManagerFactoryBuilder.class,
 					"(osgi.unit.name=emfBuilderTestUnit)");
 			assertNotNull(
@@ -102,8 +102,8 @@ public class JPAService_1_1_TestCase extends DefaultTestBundleControl {
 		// Install the bundles necessary for this test
 		Bundle persistenceBundle = installBundle("emfBuilderBundle.jar");
 		EntityManagerFactoryBuilder emfBuilder = null;
-		waitForService(EntityManagerFactoryBuilder.class, true);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class, true);
 			emfBuilder = getService(EntityManagerFactoryBuilder.class,
 					"(osgi.unit.name=emfBuilderTestUnit)");
 			assertNotNull(
@@ -160,8 +160,8 @@ public class JPAService_1_1_TestCase extends DefaultTestBundleControl {
 		// Install the bundles necessary for this test
 				Bundle persistenceBundle = installBundle("emfBuilderBundle.jar");
 				EntityManagerFactoryBuilder emfBuilder = null;
-				waitForService(EntityManagerFactoryBuilder.class, true);
 				try {
+					waitForService(EntityManagerFactoryBuilder.class, true);
 					emfBuilder = getService(EntityManagerFactoryBuilder.class,
 							"(osgi.unit.name=emfBuilderTestUnit)");
 					assertNotNull(
@@ -227,8 +227,8 @@ public class JPAService_1_1_TestCase extends DefaultTestBundleControl {
 		Bundle persistenceBundle = installBundle("emfBuilderBundle.jar");
 		EntityManagerFactoryBuilder emfBuilder = null;
 		EntityManagerFactory emf = null;
-		waitForService(EntityManagerFactoryBuilder.class, true);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class, true);
 			emfBuilder = getService(EntityManagerFactoryBuilder.class,
 					"(osgi.unit.name=emfBuilderTestUnit)");
 			assertNotNull(

--- a/org.osgi.test.cases.jpa/src/org/osgi/test/cases/jpa/junit/JPATestCase.java
+++ b/org.osgi.test.cases.jpa/src/org/osgi/test/cases/jpa/junit/JPATestCase.java
@@ -46,8 +46,8 @@ public class JPATestCase extends DefaultTestBundleControl {
 		// Install the bundles necessary for this test
 		Bundle persistenceBundle = installBundle("staticAccessBundle.jar");
 		EntityManagerFactory emf = null;
-		waitForService(EntityManagerFactory.class);
 		try {
+			waitForService(EntityManagerFactory.class);
 			emf = Persistence.createEntityManagerFactory("staticAccessTestUnit");
 			assertNotNull("Unable to create the specified EntityManagerFactory", emf);
 		} finally {
@@ -63,8 +63,8 @@ public class JPATestCase extends DefaultTestBundleControl {
 		// Install the bundles necessary for this test
 		Bundle persistenceBundle = installBundle("staticAccessWithMapBundle.jar");
 		EntityManagerFactory emf = null;
-		waitForService(EntityManagerFactoryBuilder.class);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class);
 			DataSourceFactory dsf = getService(DataSourceFactory.class);
 			ServiceReference< ? > dsfRef = getServiceReference(dsf);
 			assertNotNull("Unable to retrieve a reference for the DataSourceFactory service", dsfRef);
@@ -84,8 +84,8 @@ public class JPATestCase extends DefaultTestBundleControl {
 		// Install the bundles necessary for this test
 		Bundle persistenceBundle = installBundle("emfBundle.jar");
 		EntityManagerFactory emf = null;
-		waitForService(EntityManagerFactory.class);
 		try {
+			waitForService(EntityManagerFactory.class);
 			emf = getService(EntityManagerFactory.class, "(osgi.unit.name=emfTestUnit)");
 			assertNotNull("Unable to retrieve the specified EntityManagerFactory", emf);
 		} finally {
@@ -101,8 +101,8 @@ public class JPATestCase extends DefaultTestBundleControl {
 	public void testEntityManagerFactoryWithIncompletePersistenceUnit() throws Exception {
 		// Install the bundles necessary for this test
 		Bundle persistenceBundle = installBundle("incompletePersistenceUnitBundle.jar");
-		waitForService(EntityManagerFactoryBuilder.class);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class);
 			ServiceReference< ? >[] emfRefs = getContext().getServiceReferences(
 					EntityManagerFactory.class.getName(),
 					"(osgi.unit.name=incompleteTestUnit)");
@@ -118,8 +118,8 @@ public class JPATestCase extends DefaultTestBundleControl {
 		EntityManagerFactoryBuilder emfBuilder = null;
 		@SuppressWarnings("unused")
 		EntityManagerFactory emf = null;
-		waitForService(EntityManagerFactoryBuilder.class);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class);
 			emfBuilder = getService(EntityManagerFactoryBuilder.class, "(osgi.unit.name=emfBuilderTestUnit)");
 			assertNotNull("Unable to retrieve the specified EntityManagerFactoryBuilder", emfBuilder);
 			DataSourceFactory dsf = getService(DataSourceFactory.class);
@@ -147,8 +147,8 @@ public class JPATestCase extends DefaultTestBundleControl {
 		EntityManagerFactory emf1 = null;
 		@SuppressWarnings("unused")
 		EntityManagerFactory emf2 = null;
-		waitForService(EntityManagerFactoryBuilder.class);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class);
 			emfBuilder = getService(EntityManagerFactoryBuilder.class, "(osgi.unit.name=emfBuilderRebindingTestUnit)");
 			assertNotNull("Unable to retrieve the specified EntityManagerFactroyBuilder", emfBuilder);
 			DataSourceFactory dsf = getService(DataSourceFactory.class);
@@ -178,9 +178,9 @@ public class JPATestCase extends DefaultTestBundleControl {
 		EntityManagerFactoryBuilder emfBuilder = null;
 		EntityManagerFactory emf1 = null;
 		EntityManagerFactory emf2 = null;
-		waitForService(EntityManagerFactory.class);
-		waitForService(EntityManagerFactoryBuilder.class);
 		try {
+			waitForService(EntityManagerFactory.class);
+			waitForService(EntityManagerFactoryBuilder.class);
 			emf1 = getService(EntityManagerFactory.class, "(osgi.unit.name=emfRebindingWithBuilderTestUnit)");
 			assertNotNull("Unable to retrieve the specified EntityManagerFactory", emf1);
 			assertTrue(emf1.isOpen());
@@ -214,8 +214,8 @@ public class JPATestCase extends DefaultTestBundleControl {
 		Bundle persistenceBundle = installBundle("configPropertiesBundle.jar");
 		EntityManagerFactoryBuilder emfBuilder = null;
 		EntityManagerFactory emf = null;
-		waitForService(EntityManagerFactoryBuilder.class);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class);
 			emfBuilder = getService(EntityManagerFactoryBuilder.class, "(osgi.unit.name=configPropertiesTestUnit)");
 			assertNotNull("Unable to retrieve the specified EntityManagerFactoryBuilder.", emfBuilder);
 			DataSourceFactory dsf = getService(DataSourceFactory.class);
@@ -242,8 +242,8 @@ public class JPATestCase extends DefaultTestBundleControl {
 		Bundle emfBundle = installBundle("dsfEMFBundle.jar");
 		Bundle dsfBundle = null;
 		EntityManagerFactoryBuilder emfBuilder = null;
-		waitForService(EntityManagerFactory.class);
 		try {
+			waitForService(EntityManagerFactory.class);
 			DataSourceFactory dsf = getService(DataSourceFactory.class);
 			ServiceReference< ? > dsfRef = getServiceReference(dsf);
 			ungetService(dsf);
@@ -270,8 +270,8 @@ public class JPATestCase extends DefaultTestBundleControl {
 		// Install the bundles necessary for this test
 		Bundle persistenceBundle = installBundle("emfBundle.jar");
 		EntityManagerFactory emf = null;
-		waitForService(EntityManagerFactory.class);
 		try {
+			waitForService(EntityManagerFactory.class);
 			emf = getService(EntityManagerFactory.class, "(osgi.unit.name=emfTestUnit)");
 			assertNotNull("Unable to retrieve the specified EntityManagerFactory", emf);
 			uninstallBundle(persistenceBundle);
@@ -290,8 +290,8 @@ public class JPATestCase extends DefaultTestBundleControl {
 		// Reinstall the bundle and go through the motions again to make sure nothing that conflicts was left behind
 		Bundle reinstalledBundle = installBundle("emfBundle.jar");
 		emf = null;
-		waitForService(EntityManagerFactory.class);
 		try {
+			waitForService(EntityManagerFactory.class);
 			emf = getService(EntityManagerFactory.class, "(osgi.unit.name=emfTestUnit)");
 			assertNotNull("Unable to retrieve the specified EntityManagerFactory", emf);
 		} finally {
@@ -310,7 +310,7 @@ public class JPATestCase extends DefaultTestBundleControl {
 		assertNotNull("The javax.persistence.provider service property should be registered alongside the PersistenceProvider service", javaxPersistenceProvider);
 	}
 
-	public <S> void waitForService(Class<S> cls) {
+	public <S> S waitForService(Class<S> cls) {
 		ServiceTracker<S,S> tracker = new ServiceTracker<>(getContext(), cls,
 				null);
         tracker.open();
@@ -324,5 +324,6 @@ public class JPATestCase extends DefaultTestBundleControl {
         tracker.close();
         assertNotNull("Service for " + cls.getName() + " was not registered after waiting " +
             SERVICE_WAIT_TIME + " milliseconds", service);
+		return service;
     }
 }

--- a/org.osgi.test.cases.jpa/src/org/osgi/test/cases/jpa/junit/PersistenceUnitTests.java
+++ b/org.osgi.test.cases.jpa/src/org/osgi/test/cases/jpa/junit/PersistenceUnitTests.java
@@ -44,8 +44,8 @@ public class PersistenceUnitTests extends DefaultTestBundleControl {
 	public void testDefaultPersistenceLocation() throws Exception {
 		Bundle persistenceBundle = installBundle("defaultPersistenceLocation.jar");
 		EntityManagerFactoryBuilder persistenceUnit = null;
-		waitForService(EntityManagerFactoryBuilder.class);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class);
 			persistenceUnit = getService (EntityManagerFactoryBuilder.class, "(osgi.unit.name=testUnit1)");
 			if (persistenceUnit == null) {
 				fail("Failed to retrieve the specified persistence unit.");
@@ -61,8 +61,8 @@ public class PersistenceUnitTests extends DefaultTestBundleControl {
 	public void testNonStandardPersistenceLocation() throws Exception {
 		Bundle persistenceBundle = installBundle("nonStandardPersistenceLocation.jar");
 		EntityManagerFactoryBuilder persistenceUnit = null;
-		waitForService(EntityManagerFactoryBuilder.class);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class);
 			persistenceUnit = getService (EntityManagerFactoryBuilder.class, "(osgi.unit.name=testUnit2)");
 			if (persistenceUnit == null) {
 				fail("Failed to retrieve the specified persistence unit.");
@@ -79,8 +79,8 @@ public class PersistenceUnitTests extends DefaultTestBundleControl {
 		Bundle persistenceBundle = installBundle("multiplePersistenceLocations.jar");
 		EntityManagerFactoryBuilder persistenceUnit1 = null;
 		EntityManagerFactoryBuilder persistenceUnit2 = null;
-		waitForService(EntityManagerFactoryBuilder.class);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class);
 			persistenceUnit1 = getService (EntityManagerFactoryBuilder.class, "(osgi.unit.name=testUnit3)");
 			if (persistenceUnit1 == null) {
 				fail("Failed to retrieve the specified persistence unit.");
@@ -104,8 +104,8 @@ public class PersistenceUnitTests extends DefaultTestBundleControl {
 	public void testNestedJarPersistenceLocation() throws Exception {
 		Bundle persistenceBundle = installBundle("nestedJarPersistenceLocation.jar");
 		EntityManagerFactoryBuilder persistenceUnit = null;
-		waitForService(EntityManagerFactoryBuilder.class);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class);
 			persistenceUnit = getService (EntityManagerFactoryBuilder.class, "(osgi.unit.name=testUnit5)");
 			if (persistenceUnit == null) {
 				fail("Failed to retrieve the specified persistence unit.");
@@ -145,8 +145,8 @@ public class PersistenceUnitTests extends DefaultTestBundleControl {
 	public void testPersistenceWithUnavailableDatasource() throws Exception {
 		Bundle persistenceBundle = installBundle("unavailableDatasourceBundle.jar");
 		EntityManagerFactoryBuilder emfBuilder = null;
-		waitForService(EntityManagerFactoryBuilder.class);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class);
 			emfBuilder = getService(EntityManagerFactoryBuilder.class, "(osgi.unit.name=unavailableDSTestUnit)");
 			assertNotNull("The EntityManagerFactoryBuilder should be registered even if the datasource is unavailable", emfBuilder);
 		} finally {
@@ -182,8 +182,8 @@ public class PersistenceUnitTests extends DefaultTestBundleControl {
 
 	public void testPesistenceUnitServiceProperties() throws Exception {
 		Bundle persistenceBundle = installBundle("defaultPersistenceLocation.jar");
-		waitForService(EntityManagerFactoryBuilder.class);
 		try {
+			waitForService(EntityManagerFactoryBuilder.class);
 			ServiceReference< ? > unitRef = getContext().getServiceReference(
 					EntityManagerFactoryBuilder.class.getName());
 			String unitName = (String) unitRef.getProperty("osgi.unit.name");
@@ -216,7 +216,7 @@ public class PersistenceUnitTests extends DefaultTestBundleControl {
 		}
 	}
 
-	public <S> void waitForService(Class<S> cls) {
+	public <S> S waitForService(Class<S> cls) {
 		ServiceTracker<S,S> tracker = new ServiceTracker<>(getContext(), cls,
 				null);
         tracker.open();
@@ -230,5 +230,6 @@ public class PersistenceUnitTests extends DefaultTestBundleControl {
         tracker.close();
         assertNotNull("Service for " + cls.getName() + " was not registered after waiting " +
             SERVICE_WAIT_TIME + " milliseconds", service);
+		return service;
     }
 }


### PR DESCRIPTION
Currently the JPA test do not properly cleanup as they install a bundle but only uninstall it if the EMF was found.

This now moves the wait for service inside the try / finally blocks.