### PR TITLE
field-collection-type is the default and must be optional

### DIFF
--- a/org.osgi.test.cases.component.annotations/src/org/osgi/test/cases/component/annotations/junit/DS14AnnotationsTestCase.java
+++ b/org.osgi.test.cases.component.annotations/src/org/osgi/test/cases/component/annotations/junit/DS14AnnotationsTestCase.java
@@ -527,7 +527,7 @@ public class DS14AnnotationsTestCase extends AnnotationsTestCase {
 				.hasOptionalValue("reference[@name='multiple']/@scope",
 						"bundle")
 				.doesNotContain("reference[@name='multiple']/@target")
-				.hasValue("reference[@name='multiple']/@field-collection-type",
+				.hasOptionalValue("reference[@name='multiple']/@field-collection-type",
 						"service")
 
 				.hasValue("reference[@name='optional']/@interface",


### PR DESCRIPTION
currently the test asserts that the value for field-collection-type is service, but as it is the default value it could be omitted.

Fix https://github.com/osgi/osgi/issues/641