### PR TITLE
Unregistering a ServiceRegistration must not throw IllegalStateException

### DIFF
--- a/org.osgi.test.cases.framework/src/org/osgi/test/cases/framework/junit/service/ServiceRegistryTests.java
+++ b/org.osgi.test.cases.framework/src/org/osgi/test/cases/framework/junit/service/ServiceRegistryTests.java
@@ -572,13 +572,6 @@ public class ServiceRegistryTests extends OSGiTestCase {
 		assertTrue(getContext().ungetService(reference2));
 
 		registration.unregister();
-		try {
-			registration.unregister();
-			fail("! Invalid, should have thrown IllegalStateException");
-		}
-		catch (IllegalStateException e) {
-			// ignore
-		}
 	}
 
 	public void testFactoryUngetOnUnregister() {


### PR DESCRIPTION
With PR #462 the unregister method relaxed the condition to throw an IllegalStateException if the ServiceRegistration was already unregistered. Therefore this test needs to be adjusted to not expext the exception.