### PR TITLE
[ds] Add new component retention policy to control service lifecycle

### DIFF
--- a/org.osgi.service.component/src/org/osgi/service/component/annotations/Component.java
+++ b/org.osgi.service.component/src/org/osgi/service/component/annotations/Component.java
@@ -309,4 +309,29 @@ public @interface Component {
 	 * @since 1.4
 	 */
 	String[] factoryProperties() default {};
+
+	/**
+	 * The component retention policy for this Component.
+	 * 
+	 * <p>
+	 * Controls whether a component should be retained (kept activated) or
+	 * discarded (deactivated) when its use count drops to zero.
+	 * 
+	 * <p>
+	 * If not specified, the default is {@link ComponentRetentionPolicy#DISCARD}
+	 * which means the component will be deactivated when its use count drops to
+	 * zero. When set to {@link ComponentRetentionPolicy#KEEP}, the component
+	 * will remain activated even when its use count drops to zero, allowing it
+	 * to maintain state and avoid expensive reactivation cycles. The component
+	 * will still be deactivated if required services become unavailable or if
+	 * other deactivation conditions occur.
+	 * 
+	 * <p>
+	 * This element is only meaningful when the component provides a service and
+	 * {@link #immediate()} is {@code false}.
+	 * 
+	 * @see "The retention-policy attribute of the component element of a Component Description."
+	 * @since 1.5
+	 */
+	ComponentRetentionPolicy retentionPolicy() default ComponentRetentionPolicy.DISCARD;
 }

--- a/org.osgi.service.component/src/org/osgi/service/component/annotations/ComponentRetentionPolicy.java
+++ b/org.osgi.service.component/src/org/osgi/service/component/annotations/ComponentRetentionPolicy.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+
+package org.osgi.service.component.annotations;
+
+/**
+ * Component Retention Policy for the {@link Component} annotation.
+ * 
+ * <p>
+ * Controls whether a component should be retained (kept activated) or discarded
+ * (deactivated) when its use count drops to zero.
+ * 
+ * @author $Id$
+ * @since 1.5
+ */
+public enum ComponentRetentionPolicy {
+	/**
+	 * Deactivate and discard the component when its use count drops to zero.
+	 * This is the default behavior.
+	 */
+	DISCARD("discard"),
+
+	/**
+	 * Keep the component activated even when its use count drops to zero.
+	 * The component will still be deactivated if required services become
+	 * unavailable or if other deactivation conditions occur.
+	 */
+	KEEP("keep");
+
+	private final String	value;
+
+	ComponentRetentionPolicy(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return value;
+	}
+}

--- a/osgi.specs/docbook/112/service.component.xml
+++ b/osgi.specs/docbook/112/service.component.xml
@@ -2326,6 +2326,39 @@ public class MyComponent {
               one method which is to be used as the modified
               method.</para></entry>
             </row>
+
+            <row>
+              <entry><code>retention-policy</code></entry>
+
+              <entry><para><xref
+              linkend="org.osgi.service.component.annotations.Component.retentionPolicy--"
+              xrefstyle="hyperlink"/></para><para><xref
+              linkend="org.osgi.service.component.annotations.ComponentRetentionPolicy.DISCARD"
+              xrefstyle="hyperlink"/></para><para><xref
+              linkend="org.osgi.service.component.annotations.ComponentRetentionPolicy.KEEP"
+              xrefstyle="hyperlink"/></para></entry>
+
+              <entry><para>Controls whether a component should be retained
+              (kept activated) or discarded (deactivated) when its use count
+              drops to zero. This allows components to maintain state and
+              avoid expensive reactivation cycles.</para><itemizedlist>
+                  <listitem>
+                    <para><code>discard</code> - (default) Deactivate and
+                    discard the component when its use count drops to zero.
+                    This is the current behavior.</para>
+                  </listitem>
+
+                  <listitem>
+                    <para><code>keep</code> - Keep the component activated
+                    even when its use count drops to zero. The component will
+                    still be deactivated if required services become
+                    unavailable or if other deactivation conditions
+                    occur.</para>
+                  </listitem>
+                </itemizedlist><para>This attribute is only meaningful when
+              the component provides a service and <code>immediate</code> is
+              <code>false</code>.</para></entry>
+            </row>
           </tbody>
         </tgroup>
       </table>
@@ -3584,14 +3617,36 @@ public class FooImpl implements Foo {
       when it stops being used as a service object since the component
       configuration must not be reused as a service object. If the service has
       the <code>scope</code> attribute set to <code>singleton</code> or
-      <code>bundle</code>, SCR must deactivate a component configuration when
-      it stops being used as a service object after a delay since the
-      component configuration may be reused as a service object in the near
-      future. This allows SCR implementations to reclaim component
-      configurations not in use while attempting to avoid deactivating a
-      component configuration only to have to quickly activate a new component
-      configuration for a new service request. The delay amount is
-      implementation specific and may be zero.</para>
+      <code>bundle</code>, the behavior when a component configuration stops
+      being used as a service object depends on the
+      <code>retention-policy</code> attribute:</para>
+
+      <itemizedlist>
+        <listitem>
+          <para>If <code>retention-policy</code> is set to
+          <code>discard</code> (the default), SCR must deactivate a component
+          configuration when it stops being used as a service object after a
+          delay since the component configuration may be reused as a service
+          object in the near future. This allows SCR implementations to
+          reclaim component configurations not in use while attempting to
+          avoid deactivating a component configuration only to have to quickly
+          activate a new component configuration for a new service request.
+          The delay amount is implementation specific and may be zero.</para>
+        </listitem>
+
+        <listitem>
+          <para>If <code>retention-policy</code> is set to <code>keep</code>,
+          SCR must not deactivate the component configuration when it stops
+          being used as a service object. The component configuration remains
+          activated and available for reuse. This allows components that are
+          expensive to activate or deactivate, or that maintain caches of
+          data, to avoid repeated activation cycles. The component
+          configuration will still be deactivated if it becomes unsatisfied
+          for other reasons, such as required services becoming unavailable,
+          configuration being deleted, the component being disabled, or the
+          bundle being stopped.</para>
+        </listitem>
+      </itemizedlist>
 
       <figure xml:id="i1462979">
         <title>Delayed Component Configuration</title>


### PR DESCRIPTION
Fixes https://github.com/osgi/osgi/issues/720

---

Addresses #720: Components that are expensive to activate/deactivate or maintain caches currently have no control over lifecycle when service use count drops to zero. They either stay permanently active (`immediate=true`) or get deactivated on every idle period (`immediate=false`).

## Changes

### Java API
- **`ComponentRetentionPolicy` enum**: `DISCARD` (default, current behavior) and `KEEP` (retain on idle)
- **`@Component.retentionPolicy()`**: New attribute controlling deactivation behavior when use count reaches zero

### Specification (service.component.xml)
- **Component Element**: Added `retention-policy` attribute documentation
- **Delayed Component lifecycle**: Updated to specify `KEEP` prevents deactivation on idle while still deactivating on unsatisfied conditions (required services unavailable, config deleted, component disabled, bundle stopped)

## Example Usage

```java
@Component(
    service = DatabaseService.class,
    immediate = false,
    retentionPolicy = ComponentRetentionPolicy.KEEP
)
public class DatabaseServiceImpl implements DatabaseService {
    private ConnectionPool pool;
    private Map<String, CachedResult> cache;
    
    @Activate
    void activate() {
        pool = new ConnectionPool();  // Expensive initialization
        cache = new HashMap<>();
    }
    
    // Component stays activated between service requests,
    // avoiding pool recreation and cache loss
}
```