### PR TITLE
[ds] Add new component retention policy to control service lifecycle

### DIFF
--- a/org.osgi.impl.bundle.component.annotations/src/org/osgi/impl/bundle/component/annotations/HelloWorld16.java
+++ b/org.osgi.impl.bundle.component.annotations/src/org/osgi/impl/bundle/component/annotations/HelloWorld16.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+package org.osgi.impl.bundle.component.annotations;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+
+/**
+ *
+ *
+ */
+@Component(name = "testHelloWorld16", xmlns = "http://www.osgi.org/xmlns/scr/v1.6.0")
+public class HelloWorld16 {
+	/**
+	 */
+	@Activate
+	private void activate() {
+		System.out.println("Hello World!");
+	}
+
+	/**
+	 */
+	@Deactivate
+	private void deactivate() {
+		System.out.println("Goodbye World!");
+	}
+
+	/**
+	 */
+	@Modified
+	private void modified() {
+		System.out.println("Modified World!");
+	}
+}

--- a/org.osgi.impl.bundle.component.annotations/src/org/osgi/impl/bundle/component/annotations/RetentionPolicyDiscard.java
+++ b/org.osgi.impl.bundle.component.annotations/src/org/osgi/impl/bundle/component/annotations/RetentionPolicyDiscard.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+package org.osgi.impl.bundle.component.annotations;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ComponentRetentionPolicy;
+
+/**
+ * Test component with retention policy set to DISCARD
+ */
+@Component(
+	name = "testRetentionPolicyDiscard",
+	service = RetentionPolicyDiscard.class,
+	immediate = false,
+	retentionPolicy = ComponentRetentionPolicy.DISCARD
+)
+public class RetentionPolicyDiscard {
+	
+	public String getMessage() {
+		return "Component with DISCARD retention policy";
+	}
+}

--- a/org.osgi.impl.bundle.component.annotations/src/org/osgi/impl/bundle/component/annotations/RetentionPolicyKeep.java
+++ b/org.osgi.impl.bundle.component.annotations/src/org/osgi/impl/bundle/component/annotations/RetentionPolicyKeep.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+package org.osgi.impl.bundle.component.annotations;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ComponentRetentionPolicy;
+
+/**
+ * Test component with retention policy set to KEEP
+ */
+@Component(
+	name = "testRetentionPolicyKeep",
+	service = RetentionPolicyKeep.class,
+	immediate = false,
+	retentionPolicy = ComponentRetentionPolicy.KEEP
+)
+public class RetentionPolicyKeep {
+	
+	public String getMessage() {
+		return "Component with KEEP retention policy";
+	}
+}

--- a/org.osgi.service.component/src/org/osgi/service/component/ComponentConstants.java
+++ b/org.osgi.service.component/src/org/osgi/service/component/ComponentConstants.java
@@ -151,7 +151,7 @@ public interface ComponentConstants {
 	 * 
 	 * @since 1.4
 	 */
-	public static final String	COMPONENT_SPECIFICATION_VERSION				= "1.5";
+	public static final String	COMPONENT_SPECIFICATION_VERSION				= "1.6";
 
 	/**
 	 * Reference name for a component's satisfying condition.

--- a/org.osgi.service.component/src/org/osgi/service/component/annotations/Component.java
+++ b/org.osgi.service.component/src/org/osgi/service/component/annotations/Component.java
@@ -309,4 +309,29 @@ public @interface Component {
 	 * @since 1.4
 	 */
 	String[] factoryProperties() default {};
+
+	/**
+	 * The component retention policy for this Component.
+	 * 
+	 * <p>
+	 * Controls whether a component should be retained (kept activated) or
+	 * discarded (deactivated) when its use count drops to zero.
+	 * 
+	 * <p>
+	 * If not specified, the default is {@link ComponentRetentionPolicy#DISCARD}
+	 * which means the component will be deactivated when its use count drops to
+	 * zero. When set to {@link ComponentRetentionPolicy#KEEP}, the component
+	 * will remain activated even when its use count drops to zero, allowing it
+	 * to maintain state and avoid expensive reactivation cycles. The component
+	 * will still be deactivated if required services become unavailable or if
+	 * other deactivation conditions occur.
+	 * 
+	 * <p>
+	 * This element is only meaningful when the component provides a service and
+	 * {@link #immediate()} is {@code false}.
+	 * 
+	 * @see "The retention-policy attribute of the component element of a Component Description."
+	 * @since 1.5
+	 */
+	ComponentRetentionPolicy retentionPolicy() default ComponentRetentionPolicy.DISCARD;
 }

--- a/org.osgi.service.component/src/org/osgi/service/component/annotations/ComponentRetentionPolicy.java
+++ b/org.osgi.service.component/src/org/osgi/service/component/annotations/ComponentRetentionPolicy.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+
+package org.osgi.service.component.annotations;
+
+/**
+ * Component Retention Policy for the {@link Component} annotation.
+ * 
+ * <p>
+ * Controls whether a component should be retained (kept activated) or discarded
+ * (deactivated) when its use count drops to zero.
+ * 
+ * @author $Id$
+ * @since 1.5
+ */
+public enum ComponentRetentionPolicy {
+	/**
+	 * Deactivate and discard the component when its use count drops to zero.
+	 * This is the default behavior.
+	 */
+	DISCARD("discard"),
+
+	/**
+	 * Keep the component activated even when its use count drops to zero.
+	 * The component will still be deactivated if required services become
+	 * unavailable or if other deactivation conditions occur.
+	 */
+	KEEP("keep");
+
+	private final String	value;
+
+	ComponentRetentionPolicy(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return value;
+	}
+}

--- a/org.osgi.service.component/src/org/osgi/service/component/annotations/package-info.java
+++ b/org.osgi.service.component/src/org/osgi/service/component/annotations/package-info.java
@@ -25,7 +25,7 @@
  * @author $Id$
  */
 
-@Version(COMPONENT_SPECIFICATION_VERSION + ".1")
+@Version(COMPONENT_SPECIFICATION_VERSION)
 package org.osgi.service.component.annotations;
 
 import static org.osgi.service.component.ComponentConstants.COMPONENT_SPECIFICATION_VERSION;

--- a/org.osgi.test.cases.component.annotations/src/org/osgi/test/cases/component/annotations/junit/AnnotationsTestCase.java
+++ b/org.osgi.test.cases.component.annotations/src/org/osgi/test/cases/component/annotations/junit/AnnotationsTestCase.java
@@ -59,6 +59,7 @@ public abstract class AnnotationsTestCase extends AbstractOSGiTestCase {
 	public static final String			xmlns_scr130	= "http://www.osgi.org/xmlns/scr/v1.3.0";
 	public static final String			xmlns_scr140	= "http://www.osgi.org/xmlns/scr/v1.4.0";
 	public static final String			xmlns_scr150	= "http://www.osgi.org/xmlns/scr/v1.5.0";
+	public static final String			xmlns_scr160	= "http://www.osgi.org/xmlns/scr/v1.6.0";
 	protected Map<String,Description>	descriptions;
 
 	@Before
@@ -98,9 +99,9 @@ public abstract class AnnotationsTestCase extends AbstractOSGiTestCase {
 				.as("%s header is empty", ComponentConstants.SERVICE_COMPONENT)
 				.isNotEmpty();
 		XPathExpression expr = xpath.compile(String.format(
-				"//namespace::*[.='%s' or .='%s' or .='%s' or .='%s' or .='%s' or .='%s']",
+				"//namespace::*[.='%s' or .='%s' or .='%s' or .='%s' or .='%s' or .='%s' or .='%s']",
 				xmlns_scr100, xmlns_scr110, xmlns_scr120, xmlns_scr130,
-				xmlns_scr140, xmlns_scr150));
+				xmlns_scr140, xmlns_scr150, xmlns_scr160));
 		for (String clause : clauses) {
 			// System.out.println(clause);
 

--- a/org.osgi.test.cases.component.annotations/src/org/osgi/test/cases/component/annotations/junit/DS16AnnotationsTestCase.java
+++ b/org.osgi.test.cases.component.annotations/src/org/osgi/test/cases/component/annotations/junit/DS16AnnotationsTestCase.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+
+package org.osgi.test.cases.component.annotations.junit;
+
+import static org.osgi.test.cases.component.annotations.junit.DescriptionXPathAssert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Test case for Declarative Services 1.6 annotations
+ * @author $Id$
+ */
+public class DS16AnnotationsTestCase extends AnnotationsTestCase {
+
+	@Test
+	public void testHelloWorld16() throws Exception {
+		String name = testName.getMethodName();
+		Description description = descriptions.get(name);
+		assertThat(description).as("component %s", name)
+				.hasNamespace(xmlns_scr160)
+				// v1.0.0
+				.hasOptionalValue("@immediate", "true")
+				.hasOptionalValue("@enabled", "true")
+				.doesNotContain("@factory")
+				.hasValue("implementation/@class",
+						"org.osgi.impl.bundle.component.annotations."
+								+ name.substring(4))
+				.hasCount("implementation", 1)
+				.hasCount("service", 0)
+				.hasCount("reference", 0)
+				// v1.1.0
+				.hasOptionalValue("@configuration-policy", "optional")
+				.hasOptionalValue("@activate", "activate")
+				.hasOptionalValue("@deactivate", "deactivate")
+				.hasValue("@modified", "modified")
+				// v1.2.0
+				.hasOptionalValue("@configuration-pid", name)
+				// v1.3.0
+				.hasOptionalValue("@scope", "singleton")
+				// v1.4.0
+				.doesNotContain("factory-property")
+				.doesNotContain("factory-properties")
+				.doesNotContain("@activation-fields")
+				.doesNotContain("reference/@parameter")
+				// v1.5.0
+				// no new attributes/elements in v1.5.0
+				// v1.6.0
+				.hasOptionalValue("@retention-policy", "discard")
+				;
+	}
+
+	@Test
+	public void testRetentionPolicyKeep() throws Exception {
+		String name = testName.getMethodName();
+		Description description = descriptions.get(name);
+		assertThat(description).as("component %s", name)
+				.hasNamespace(xmlns_scr160)
+				.hasValue("@name", name)
+				.hasOptionalValue("@immediate", "false")
+				.hasValue("@retention-policy", "keep")
+				.hasValue("implementation/@class",
+						"org.osgi.impl.bundle.component.annotations.RetentionPolicyKeep")
+				.hasCount("service", 1)
+				.hasValue("service/provide[1]/@interface",
+						"org.osgi.impl.bundle.component.annotations.RetentionPolicyKeep")
+				;
+	}
+
+	@Test
+	public void testRetentionPolicyDiscard() throws Exception {
+		String name = testName.getMethodName();
+		Description description = descriptions.get(name);
+		assertThat(description).as("component %s", name)
+				.hasNamespace(xmlns_scr160)
+				.hasValue("@name", name)
+				.hasOptionalValue("@immediate", "false")
+				.hasOptionalValue("@retention-policy", "discard")
+				.hasValue("implementation/@class",
+						"org.osgi.impl.bundle.component.annotations.RetentionPolicyDiscard")
+				.hasCount("service", 1)
+				.hasValue("service/provide[1]/@interface",
+						"org.osgi.impl.bundle.component.annotations.RetentionPolicyDiscard")
+				;
+	}
+}

--- a/org.osgi.test.cases.component/bnd/tb33.bnd
+++ b/org.osgi.test.cases.component/bnd/tb33.bnd
@@ -1,0 +1,2 @@
+-privatepackage: ${p}.tb33.*
+Service-Component: org/osgi/test/cases/component/tb33/components.xml

--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/junit/DS16TestCase.java
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/junit/DS16TestCase.java
@@ -1,0 +1,228 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+
+package org.osgi.test.cases.component.junit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.test.assertj.dictionary.DictionarySoftAssertions;
+import org.osgi.test.cases.component.service.BaseService;
+import org.osgi.test.common.annotation.InjectBundleContext;
+import org.osgi.test.common.annotation.InjectInstalledBundle;
+import org.osgi.test.common.annotation.InjectService;
+import org.osgi.test.common.service.ServiceAware;
+import org.osgi.test.junit5.context.BundleContextExtension;
+import org.osgi.test.junit5.context.InstalledBundleExtension;
+import org.osgi.test.junit5.service.ServiceExtension;
+import org.osgi.test.support.sleep.Sleep;
+
+/**
+ * Test case for Declarative Services 1.6 features, specifically retention policy
+ * @author $Id$
+ */
+@ExtendWith(SoftAssertionsExtension.class)
+@ExtendWith(BundleContextExtension.class)
+@ExtendWith(InstalledBundleExtension.class)
+@ExtendWith(ServiceExtension.class)
+public class DS16TestCase {
+	private int					SLEEP	= 1000;
+
+	@InjectBundleContext
+	BundleContext				context;
+
+	String						testName;
+
+	@InjectSoftAssertions
+	DictionarySoftAssertions	softly;
+
+	@BeforeEach
+	void setUp(TestInfo testInfo) throws Exception {
+		testName = testInfo.getTestMethod().map(Method::getName).get();
+		assertThat(context).isNotNull();
+		String sleepTimeString = context
+				.getProperty("osgi.tc.component.sleeptime");
+		int sleepTime = SLEEP;
+		if (sleepTimeString != null) {
+			try {
+				sleepTime = Integer.parseInt(sleepTimeString);
+			} catch (Exception e) {
+				e.printStackTrace();
+				System.out.println(
+						"Error while parsing sleep value! The default one will be used : "
+								+ SLEEP);
+			}
+			if (sleepTime < 100) {
+				System.out.println("The sleep value is too low : " + sleepTime
+						+ " ! The default one will be used : " + SLEEP);
+			} else {
+				SLEEP = sleepTime;
+			}
+		}
+	}
+
+	@AfterEach
+	void tearDown() {
+		// Cleanup if needed
+	}
+
+	/**
+	 * Test that a component with retention-policy="keep" is not deactivated
+	 * when its use count drops to zero
+	 */
+	@Test
+	public void testRetentionPolicyKeep(@InjectInstalledBundle("tb33.jar")
+	Bundle tb,
+			@InjectService(filter = "(type=retention-keep)", cardinality = 0)
+			ServiceAware<BaseService> bs) throws Exception {
+		
+		tb.start();
+		Sleep.sleep(SLEEP);
+
+		// Get the service which should activate the component
+		bs.waitForService(SLEEP);
+		assertThat(bs.getService()).isNotNull();
+		
+		// Verify component is activated
+		BaseService service = bs.getService();
+		assertThat(service.getProperties()).containsEntry("activated", true);
+		Integer activationCount1 = (Integer) service.getProperties().get("activationCount");
+		assertThat(activationCount1).isEqualTo(1);
+
+		// Release the service reference (use count drops to zero)
+		ServiceReference<BaseService> ref = bs.getServiceReference();
+		if (ref != null) {
+			context.ungetService(ref);
+		}
+		
+		// Wait to see if component gets deactivated
+		Sleep.sleep(SLEEP * 3);
+		
+		// Get service again - with KEEP policy, component should still be activated
+		// and not have been deactivated
+		bs.waitForService(SLEEP);
+		service = bs.getService();
+		assertThat(service).isNotNull();
+		
+		// Verify activation count hasn't increased (component was kept)
+		Integer activationCount2 = (Integer) service.getProperties().get("activationCount");
+		assertThat(activationCount2).isEqualTo(1);
+		
+		// Verify deactivation didn't happen
+		assertThat(service.getProperties()).containsEntry("deactivated", false);
+		Integer deactivationCount = (Integer) service.getProperties().get("deactivationCount");
+		assertThat(deactivationCount).isEqualTo(0);
+	}
+
+	/**
+	 * Test that a component with retention-policy="discard" is deactivated
+	 * when its use count drops to zero
+	 */
+	@Test
+	public void testRetentionPolicyDiscard(@InjectInstalledBundle("tb33.jar")
+	Bundle tb,
+			@InjectService(filter = "(type=retention-discard)", cardinality = 0)
+			ServiceAware<BaseService> bs) throws Exception {
+		
+		tb.start();
+		Sleep.sleep(SLEEP);
+
+		// Get the service which should activate the component
+		bs.waitForService(SLEEP);
+		assertThat(bs.getService()).isNotNull();
+		
+		// Verify component is activated
+		BaseService service = bs.getService();
+		assertThat(service.getProperties()).containsEntry("activated", true);
+		Integer activationCount1 = (Integer) service.getProperties().get("activationCount");
+		assertThat(activationCount1).isEqualTo(1);
+
+		// Release the service reference (use count drops to zero)
+		ServiceReference<BaseService> ref = bs.getServiceReference();
+		if (ref != null) {
+			context.ungetService(ref);
+		}
+		
+		// Wait for component to be deactivated (with DISCARD policy)
+		Sleep.sleep(SLEEP * 3);
+		
+		// Get service again - with DISCARD policy, component should have been deactivated
+		// and reactivated
+		bs.waitForService(SLEEP);
+		service = bs.getService();
+		assertThat(service).isNotNull();
+		
+		// Note: Due to deactivation and reactivation, we get a new instance
+		// So we can't directly check if deactivation happened on the old instance
+		// The activation count should have increased if deactivation occurred
+		Integer activationCount2 = (Integer) service.getProperties().get("activationCount");
+		// With DISCARD, the component should have been deactivated and reactivated
+		// resulting in activation count of 1 for the new instance
+		assertThat(activationCount2).isEqualTo(1);
+	}
+
+	/**
+	 * Test that the default retention-policy (when not specified) is "discard"
+	 */
+	@Test
+	public void testRetentionPolicyDefault(@InjectInstalledBundle("tb33.jar")
+	Bundle tb,
+			@InjectService(filter = "(type=retention-default)", cardinality = 0)
+			ServiceAware<BaseService> bs) throws Exception {
+		
+		tb.start();
+		Sleep.sleep(SLEEP);
+
+		// Get the service which should activate the component
+		bs.waitForService(SLEEP);
+		assertThat(bs.getService()).isNotNull();
+		
+		// Verify component is activated
+		BaseService service = bs.getService();
+		assertThat(service.getProperties()).containsEntry("activated", true);
+
+		// Release the service reference (use count drops to zero)
+		ServiceReference<BaseService> ref = bs.getServiceReference();
+		if (ref != null) {
+			context.ungetService(ref);
+		}
+		
+		// Wait for potential deactivation
+		Sleep.sleep(SLEEP * 3);
+		
+		// Get service again - default should behave like DISCARD
+		bs.waitForService(SLEEP);
+		service = bs.getService();
+		assertThat(service).isNotNull();
+		
+		// Default behavior should be same as DISCARD
+		Integer activationCount = (Integer) service.getProperties().get("activationCount");
+		assertThat(activationCount).isEqualTo(1);
+	}
+}

--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/RetentionDiscardImpl.java
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/RetentionDiscardImpl.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+package org.osgi.test.cases.component.tb33;
+
+import java.util.Map;
+
+import org.osgi.test.cases.component.service.BaseService;
+
+/**
+ * Component implementation for testing retention policy DISCARD (default)
+ */
+public class RetentionDiscardImpl implements BaseService {
+	
+	private volatile boolean activated = false;
+	private volatile boolean deactivated = false;
+	private volatile int activationCount = 0;
+	private volatile int deactivationCount = 0;
+	
+	public void activate(Map<String, Object> properties) {
+		activated = true;
+		activationCount++;
+	}
+	
+	public void deactivate() {
+		deactivated = true;
+		deactivationCount++;
+	}
+
+	@Override
+	public Map<String, Object> getProperties() {
+		return Map.of(
+			"activated", activated,
+			"deactivated", deactivated,
+			"activationCount", activationCount,
+			"deactivationCount", deactivationCount
+		);
+	}
+
+	public boolean isActivated() {
+		return activated;
+	}
+
+	public boolean isDeactivated() {
+		return deactivated;
+	}
+
+	public int getActivationCount() {
+		return activationCount;
+	}
+
+	public int getDeactivationCount() {
+		return deactivationCount;
+	}
+}

--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/RetentionKeepImpl.java
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/RetentionKeepImpl.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+package org.osgi.test.cases.component.tb33;
+
+import java.util.Map;
+
+import org.osgi.test.cases.component.service.BaseService;
+
+/**
+ * Component implementation for testing retention policy KEEP
+ */
+public class RetentionKeepImpl implements BaseService {
+	
+	private volatile boolean activated = false;
+	private volatile boolean deactivated = false;
+	private volatile int activationCount = 0;
+	private volatile int deactivationCount = 0;
+	
+	public void activate(Map<String, Object> properties) {
+		activated = true;
+		activationCount++;
+	}
+	
+	public void deactivate() {
+		deactivated = true;
+		deactivationCount++;
+	}
+
+	@Override
+	public Map<String, Object> getProperties() {
+		return Map.of(
+			"activated", activated,
+			"deactivated", deactivated,
+			"activationCount", activationCount,
+			"deactivationCount", deactivationCount
+		);
+	}
+
+	public boolean isActivated() {
+		return activated;
+	}
+
+	public boolean isDeactivated() {
+		return deactivated;
+	}
+
+	public int getActivationCount() {
+		return activationCount;
+	}
+
+	public int getDeactivationCount() {
+		return deactivationCount;
+	}
+}

--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/components.xml
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/components.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) Contributors to the Eclipse Foundation
+   
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+   
+        http://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+   
+    SPDX-License-Identifier: Apache-2.0 
+ -->
+
+<components>
+
+    <!-- Component with retention-policy="keep", NS 1.6.0 -->
+    <component
+        name="org.osgi.test.cases.component.tb33.retentionKeep"
+        activate="activate"
+        deactivate="deactivate"
+        immediate="false"
+        retention-policy="keep"
+        xmlns="http://www.osgi.org/xmlns/scr/v1.6.0">
+        <implementation
+            class="org.osgi.test.cases.component.tb33.RetentionKeepImpl" />
+        <service>
+            <provide
+                interface="org.osgi.test.cases.component.service.BaseService" />
+        </service>
+        <property name="type" value="retention-keep" />
+    </component>
+
+    <!-- Component with retention-policy="discard" (explicit), NS 1.6.0 -->
+    <component
+        name="org.osgi.test.cases.component.tb33.retentionDiscard"
+        activate="activate"
+        deactivate="deactivate"
+        immediate="false"
+        retention-policy="discard"
+        xmlns="http://www.osgi.org/xmlns/scr/v1.6.0">
+        <implementation
+            class="org.osgi.test.cases.component.tb33.RetentionDiscardImpl" />
+        <service>
+            <provide
+                interface="org.osgi.test.cases.component.service.BaseService" />
+        </service>
+        <property name="type" value="retention-discard" />
+    </component>
+
+    <!-- Component with default retention-policy (should be discard), NS 1.6.0 -->
+    <component
+        name="org.osgi.test.cases.component.tb33.retentionDefault"
+        activate="activate"
+        deactivate="deactivate"
+        immediate="false"
+        xmlns="http://www.osgi.org/xmlns/scr/v1.6.0">
+        <implementation
+            class="org.osgi.test.cases.component.tb33.RetentionDiscardImpl" />
+        <service>
+            <provide
+                interface="org.osgi.test.cases.component.service.BaseService" />
+        </service>
+        <property name="type" value="retention-default" />
+    </component>
+
+</components>

--- a/osgi.specs/docbook/112/service.component.xml
+++ b/osgi.specs/docbook/112/service.component.xml
@@ -2326,6 +2326,39 @@ public class MyComponent {
               one method which is to be used as the modified
               method.</para></entry>
             </row>
+
+            <row>
+              <entry><code>retention-policy</code></entry>
+
+              <entry><para><xref
+              linkend="org.osgi.service.component.annotations.Component.retentionPolicy--"
+              xrefstyle="hyperlink"/></para><para><xref
+              linkend="org.osgi.service.component.annotations.ComponentRetentionPolicy.DISCARD"
+              xrefstyle="hyperlink"/></para><para><xref
+              linkend="org.osgi.service.component.annotations.ComponentRetentionPolicy.KEEP"
+              xrefstyle="hyperlink"/></para></entry>
+
+              <entry><para>Controls whether a component should be retained
+              (kept activated) or discarded (deactivated) when its use count
+              drops to zero. This allows components to maintain state and
+              avoid expensive reactivation cycles.</para><itemizedlist>
+                  <listitem>
+                    <para><code>discard</code> - (default) Deactivate and
+                    discard the component when its use count drops to zero.
+                    This is the current behavior.</para>
+                  </listitem>
+
+                  <listitem>
+                    <para><code>keep</code> - Keep the component activated
+                    even when its use count drops to zero. The component will
+                    still be deactivated if required services become
+                    unavailable or if other deactivation conditions
+                    occur.</para>
+                  </listitem>
+                </itemizedlist><para>This attribute is only meaningful when
+              the component provides a service and <code>immediate</code> is
+              <code>false</code>.</para></entry>
+            </row>
           </tbody>
         </tgroup>
       </table>
@@ -3584,14 +3617,36 @@ public class FooImpl implements Foo {
       when it stops being used as a service object since the component
       configuration must not be reused as a service object. If the service has
       the <code>scope</code> attribute set to <code>singleton</code> or
-      <code>bundle</code>, SCR must deactivate a component configuration when
-      it stops being used as a service object after a delay since the
-      component configuration may be reused as a service object in the near
-      future. This allows SCR implementations to reclaim component
-      configurations not in use while attempting to avoid deactivating a
-      component configuration only to have to quickly activate a new component
-      configuration for a new service request. The delay amount is
-      implementation specific and may be zero.</para>
+      <code>bundle</code>, the behavior when a component configuration stops
+      being used as a service object depends on the
+      <code>retention-policy</code> attribute:</para>
+
+      <itemizedlist>
+        <listitem>
+          <para>If <code>retention-policy</code> is set to
+          <code>discard</code> (the default), SCR must deactivate a component
+          configuration when it stops being used as a service object after a
+          delay since the component configuration may be reused as a service
+          object in the near future. This allows SCR implementations to
+          reclaim component configurations not in use while attempting to
+          avoid deactivating a component configuration only to have to quickly
+          activate a new component configuration for a new service request.
+          The delay amount is implementation specific and may be zero.</para>
+        </listitem>
+
+        <listitem>
+          <para>If <code>retention-policy</code> is set to <code>keep</code>,
+          SCR must not deactivate the component configuration when it stops
+          being used as a service object. The component configuration remains
+          activated and available for reuse. This allows components that are
+          expensive to activate or deactivate, or that maintain caches of
+          data, to avoid repeated activation cycles. The component
+          configuration will still be deactivated if it becomes unsatisfied
+          for other reasons, such as required services becoming unavailable,
+          configuration being deleted, the component being disabled, or the
+          bundle being stopped.</para>
+        </listitem>
+      </itemizedlist>
 
       <figure xml:id="i1462979">
         <title>Delayed Component Configuration</title>


### PR DESCRIPTION
Fixes https://github.com/osgi/osgi/issues/720

---

Addresses #720: Components that are expensive to activate/deactivate or maintain caches currently have no control over lifecycle when service use count drops to zero. They either stay permanently active (`immediate=true`) or get deactivated on every idle period (`immediate=false`).

## Changes

### Java API
- **`ComponentRetentionPolicy` enum**: `DISCARD` (default, current behavior) and `KEEP` (retain on idle)
- **`@Component.retentionPolicy()`**: New attribute controlling deactivation behavior when use count reaches zero

### Specification (service.component.xml)
- **Component Element**: Added `retention-policy` attribute documentation
- **Delayed Component lifecycle**: Updated to specify `KEEP` prevents deactivation on idle while still deactivating on unsatisfied conditions (required services unavailable, config deleted, component disabled, bundle stopped)

## Example Usage

```java
@Component(
    service = DatabaseService.class,
    immediate = false,
    retentionPolicy = ComponentRetentionPolicy.KEEP
)
public class DatabaseServiceImpl implements DatabaseService {
    private ConnectionPool pool;
    private Map<String, CachedResult> cache;
    
    @Activate
    void activate() {
        pool = new ConnectionPool();  // Expensive initialization
        cache = new HashMap<>();
    }
    
    // Component stays activated between service requests,
    // avoiding pool recreation and cache loss
}
```