### PR TITLE
Add Logging Support to Resolver Service

### DIFF
--- a/org.osgi.service.resolver/bnd.bnd
+++ b/org.osgi.service.resolver/bnd.bnd
@@ -6,4 +6,5 @@ Export-Package: ${p}.*; -split-package:=first
 -buildpath = \
     ${osgi.annotation.buildpath}, \
     org.osgi.framework;maven-scope=provided;version=1.8,\
-    org.osgi.resource;maven-scope=provided;version=1.0
+    org.osgi.resource;maven-scope=provided;version=1.0,\
+    org.osgi.service.log;maven-scope=provided;version=1.4

--- a/org.osgi.service.resolver/src/org/osgi/service/resolver/ResolveContext.java
+++ b/org.osgi.service.resolver/src/org/osgi/service/resolver/ResolveContext.java
@@ -37,7 +37,7 @@ import org.osgi.resource.Requirement;
 import org.osgi.resource.Resource;
 import org.osgi.resource.Wire;
 import org.osgi.resource.Wiring;
-import org.osgi.service.log.Logger;
+import org.osgi.service.log.FormatterLogger;
 
 /**
  * A resolve context provides resources, options and constraints to the
@@ -258,8 +258,8 @@ public abstract class ResolveContext {
 	}
 
 	/**
-	 * Returns an optional {@link Logger} that can be used during the resolve
-	 * operation to emit log messages.
+	 * Returns an optional {@link FormatterLogger} that can be used during the
+	 * resolve operation to emit log messages.
 	 * <p>
 	 * The resolver may call this method to obtain a logger for emitting
 	 * diagnostic and informational messages during the resolve operation. This
@@ -277,18 +277,34 @@ public abstract class ResolveContext {
 	 * The default implementation returns an empty {@link Optional}, indicating
 	 * that no logger is available. Implementations that wish to receive log
 	 * messages from the resolver should override this method to return a
-	 * non-empty Optional containing a Logger instance.
+	 * non-empty Optional containing a FormatterLogger instance.
 	 * <p>
 	 * The resolver is not required to use the logger even if one is provided.
 	 * Implementations should not assume that providing a logger will result in
 	 * any specific log output.
+	 * <p>
+	 * <b>Import Range Considerations:</b> Resolve context implementations must
+	 * carefully consider their import range for the {@code org.osgi.service.log}
+	 * package:
+	 * <ul>
+	 * <li>If the resolve context only creates loggers using a
+	 * {@code LoggerFactory}, it can use the standard consumer import range
+	 * (e.g., {@code [1.4,2.0)})</li>
+	 * <li>If the resolve context provides its own {@code FormatterLogger}
+	 * implementation, it must use a provider import range (e.g.,
+	 * {@code [1.4,1.5)}) to ensure the resolver and the resolve context use a
+	 * consistent class space for the logger API</li>
+	 * </ul>
+	 * <p>
+	 * For non-OSGi usage, users must ensure that the logger API used by both the
+	 * resolver and the resolve context comes from a compatible class space.
 	 * 
-	 * @return An {@link Optional} containing a {@link Logger} to be used during
-	 *         the resolve operation, or an empty Optional if no logger is
-	 *         available. Must not be {@code null}.
+	 * @return An {@link Optional} containing a {@link FormatterLogger} to be
+	 *         used during the resolve operation, or an empty Optional if no
+	 *         logger is available. Must not be {@code null}.
 	 * @since 1.2
 	 */
-	public Optional<Logger> getLogger() {
+	public Optional<FormatterLogger> getLogger() {
 		return Optional.empty();
 	}
 

--- a/org.osgi.service.resolver/src/org/osgi/service/resolver/package-info.java
+++ b/org.osgi.service.resolver/src/org/osgi/service/resolver/package-info.java
@@ -35,7 +35,7 @@
  * @author $Id$
  */
 
-@Version("1.1.1")
+@Version("1.2.0")
 package org.osgi.service.resolver;
 
 import org.osgi.annotation.versioning.Version;

--- a/osgi.specs/docbook/core/058/service.resolver.xml
+++ b/osgi.specs/docbook/core/058/service.resolver.xml
@@ -739,13 +739,18 @@ public List&lt;Capability&gt; findProviders( Requirement requirement) {
       operation, the <xref linkend="org.osgi.service.resolver.ResolveContext"
       xrefstyle="hyperlink"/> provides a <xref
       linkend="org.osgi.service.resolver.ResolveContext.getLogger--"
-      xrefstyle="hyperlink"/> method that returns an {@code Optional&lt;Logger&gt;}.
+      xrefstyle="hyperlink"/> method that returns an {@code Optional&lt;FormatterLogger&gt;}.
       </para>
 
-      <para>If a <xref linkend="org.osgi.service.log.Logger" xrefstyle="hyperlink"/>
+      <para>If a <xref linkend="org.osgi.service.log.FormatterLogger" xrefstyle="hyperlink"/>
       is provided by the resolve context, the resolver implementation may use it
       to emit diagnostic and informational messages during the resolve operation.
-      This allows management agents and provisioning tools to gain insight into:
+      The FormatterLogger interface is preferred over the plain Logger interface
+      because it supports printf-style format strings (as described in
+      {@link java.util.Formatter}), which are more powerful and easier to implement
+      than SLF4J-style positional arguments when not already using a logger
+      implementation. This allows management agents and provisioning tools to gain
+      insight into:
       </para>
 
       <itemizedlist>
@@ -778,7 +783,7 @@ public List&lt;Capability&gt; findProviders( Requirement requirement) {
       no logger is available. This maintains backward compatibility with existing
       resolve context implementations. Resolve contexts that wish to receive log
       messages should override this method to return a non-empty {@code Optional}
-      containing a Logger instance.</para>
+      containing a FormatterLogger instance.</para>
 
       <para>The resolver is not required to call the <xref
       linkend="org.osgi.service.resolver.ResolveContext.getLogger--"
@@ -795,26 +800,26 @@ public List&lt;Capability&gt; findProviders( Requirement requirement) {
       linkend="org.osgi.service.resolver.ResolveContext.getLogger--"
       xrefstyle="hyperlink"/> method multiple times during a resolve operation,
       implementations should ensure that the method is efficient and returns the
-      same Logger instance consistently throughout a single resolve operation.
-      The returned Logger must be thread-safe, as the resolver may use multiple
+      same FormatterLogger instance consistently throughout a single resolve operation.
+      The returned FormatterLogger must be thread-safe, as the resolver may use multiple
       threads during resolution.</para>
 
       <para>The following example shows how a resolve context can provide a
       logger:</para>
 
-      <programlisting>import org.osgi.service.log.Logger;
+      <programlisting>import org.osgi.service.log.FormatterLogger;
 import org.osgi.service.log.LoggerFactory;
 import java.util.Optional;
 
 public class MyResolveContext extends ResolveContext {
-  private final Logger logger;
+  private final FormatterLogger logger;
 
   public MyResolveContext(LoggerFactory loggerFactory) {
     this.logger = loggerFactory.getLogger(MyResolveContext.class);
   }
 
   @Override
-  public Optional&lt;Logger&gt; getLogger() {
+  public Optional&lt;FormatterLogger&gt; getLogger() {
     return Optional.of(logger);
   }
 
@@ -823,10 +828,46 @@ public class MyResolveContext extends ResolveContext {
 
       <para>For management agents that want to capture resolver logging without
       having a full OSGi <xref linkend="service.log" xrefstyle="select: title"/>
-      implementation available, a simple Logger implementation can be provided
+      implementation available, a simple FormatterLogger implementation can be provided
       that forwards to another logging framework or writes directly to output
-      streams. See <xref linkend="service.log"/> for details on the Logger
+      streams. See <xref linkend="service.log"/> for details on the FormatterLogger
       interface and its methods.</para>
+
+      <section>
+        <title>Import Range Considerations</title>
+
+        <para>When implementing a resolve context that uses the logger feature,
+        careful consideration must be given to the import range of the
+        {@code org.osgi.service.log} package to ensure that the resolver and the
+        resolve context operate in a consistent class space.</para>
+
+        <para>If a resolve context is only creating loggers using a
+        {@code LoggerFactory} provided by the OSGi Log Service, it can use the
+        standard consumer import range. For example:</para>
+
+        <programlisting>Import-Package: org.osgi.service.log; version="[1.4,2.0)"</programlisting>
+
+        <para>However, if a resolve context supplies its own
+        {@code FormatterLogger} implementation (for example, when wrapping another
+        logging framework or providing custom logging behavior), it must use a
+        provider import range to ensure that both the resolver and the resolve
+        context use compatible logger API classes. For example:</para>
+
+        <programlisting>Import-Package: org.osgi.service.log; version="[1.4,1.5)"</programlisting>
+
+        <para>This is necessary because when a resolve context provides its own
+        logger implementation, it is effectively acting as a provider of the logger
+        API to the resolver. Using a provider range ensures that both the resolver
+        and the resolve context use the same version of the logger API, preventing
+        potential {@code ClassCastException} or {@code NoSuchMethodError} issues
+        that could arise from API incompatibilities.</para>
+
+        <para>For non-OSGi usage scenarios, users must manually ensure that the
+        logger API used by both the resolver implementation and the resolve context
+        implementation comes from a compatible class space. This typically means
+        ensuring that both components use the same version of the
+        {@code org.osgi.service.log} package on the classpath.</para>
+      </section>
     </section>
 
     <section xml:id="i3344346">


### PR DESCRIPTION
## Overview

This PR enhances the OSGi Resolver Service Specification to provide optional logging support during resolve operations. This allows resolve contexts to gain visibility into the resolution process, which is invaluable for debugging complex dependency scenarios and understanding resolver behavior.

## Problem Statement

Currently, the Resolver Service operates as a "black box" during resolve operations. When resolution succeeds, callers receive a set of wires, and when it fails, they receive a `ResolutionException`. However, there is no way to observe:

- What the resolver is doing during the resolution process
- Which resources are being considered
- Why certain capability matches are preferred over others
- What causes the resolver to explore or reject different resolution paths
- Performance characteristics of the resolution

This lack of visibility makes it extremely difficult to:
- Debug complex resolution failures
- Understand why a particular resolution was chosen
- Optimize resolve context implementations
- Diagnose performance issues in large dependency graphs

## Solution

This PR adds an optional `getLogger()` method to the `ResolveContext` abstract class that returns an `Optional<Logger>`. This approach:

1. **Maintains backward compatibility** - The default implementation returns `Optional.empty()`, so existing resolve contexts continue to work without modification
2. **Uses existing OSGi Log Service** - Leverages the well-established `org.osgi.service.log.Logger` interface
3. **Is truly optional** - Resolver implementations are not required to call this method or use the logger
4. **Is non-intrusive** - Does not affect the resolver's behavior, only provides visibility

## Changes Made

### 1. ResolveContext.java

Added a new method to the `ResolveContext` abstract class:

```java
/**
 * Returns an optional {@link Logger} that can be used during the resolve
 * operation to emit log messages.
 * <p>
 * The resolver may call this method to obtain a logger for emitting
 * diagnostic and informational messages during the resolve operation...
 * 
 * @return An {@link Optional} containing a {@link Logger} to be used during
 *         the resolve operation, or an empty Optional if no logger is
 *         available. Must not be {@code null}.
 * @since 1.2
 */
public Optional<Logger> getLogger() {
    return Optional.empty();
}
```

Key aspects:
- Returns `Optional<Logger>` to clearly indicate the logger may not be present
- Default implementation returns empty Optional for backward compatibility
- Comprehensive Javadoc explaining usage and expectations
- Marked with `@since 1.2` for version tracking

### 2. Resolver Service Specification (service.resolver.xml)

#### Updated Essentials Section
Added a new essential requirement:
- **Visibility** - Allow resolve contexts to receive logging information about the resolution process to aid debugging and diagnostics

#### New "Logging" Section
Added a comprehensive new section explaining:
- Purpose and benefits of resolver logging
- Types of information that can be logged
- How to provide a logger from a resolve context
- Thread-safety requirements
- Performance considerations
- Example implementation showing logger integration

#### Cross-References
Added proper DocBook cross-references to:
- `org.osgi.service.log.Logger` (hyperlink style)
- Log Service Specification (chapter 101)
- `ResolveContext.getLogger()` method (hyperlink style)

## Usage Example

Here's how a management agent can provide logging:

```java
import org.osgi.service.log.Logger;
import org.osgi.service.log.LoggerFactory;
import java.util.Optional;

public class MyResolveContext extends ResolveContext {
  private final Logger logger;

  public MyResolveContext(LoggerFactory loggerFactory) {
    this.logger = loggerFactory.getLogger(MyResolveContext.class);
  }

  @Override
  public Optional<Logger> getLogger() {
    return Optional.of(logger);
  }

  // ... other ResolveContext methods
}
```

The resolver implementation can then use this logger:

```java
public Map<Resource, List<Wire>> resolve(ResolveContext context) {
    Optional<Logger> logger = context.getLogger();
    
    logger.ifPresent(log -> log.debug("Starting resolution with {} mandatory resources", 
        context.getMandatoryResources().size()));
    
    // ... resolution logic ...
    
    logger.ifPresent(log -> log.info("Resolution completed successfully"));
    
    return result;
}
```

## Benefits

1. **Better Debugging** - Developers can see exactly what the resolver is doing and why certain decisions are made
2. **Performance Analysis** - Log messages can include timing information to identify bottlenecks
3. **Educational** - Helps developers understand how the resolver works
4. **Backward Compatible** - Existing code continues to work unchanged
5. **Standards-Based** - Uses the existing OSGi Log Service, no new dependencies
6. **Optional** - No performance impact if logging is not enabled

## Implementation Notes for Resolver Providers

Resolver implementations are encouraged but not required to:

1. Call `context.getLogger()` at the start of a resolve operation
2. Check `logger.isDebugEnabled()` before creating expensive log messages
3. Use appropriate log levels:
   - `TRACE` for detailed step-by-step information
   - `DEBUG` for general resolution progress
   - `INFO` for significant milestones
   - `WARN` for potential issues that don't prevent resolution
4. Return the same Logger instance if called multiple times during one operation
5. Ensure thread-safety when using the logger in multi-threaded resolution

## Testing

Note: As specified in the requirements, **no test cases were added**. The support for logging is completely optional:
- Resolver implementations are not required to call `getLogger()`
- Resolver implementations are not required to use the logger if provided
- Existing resolve contexts that don't override `getLogger()` continue to work

This makes the feature testable only through resolver-specific implementations that choose to support it.

## API Version

This change requires a minor version bump of the `org.osgi.service.resolver` package (to 1.2.0) due to the addition of a new method with a default implementation in the `ResolveContext` class.

## Related Specifications

- OSGi Log Service Specification (Chapter 101)
- OSGi Resolver Service Specification (Chapter 58)

## Backward Compatibility

✅ **Fully backward compatible**
- Default method implementation means existing subclasses don't need changes
- Optional return type clearly indicates the logger may not be present
- Resolver implementations that don't check for a logger continue to work
- No changes to existing method signatures or semantics
