### PR TITLE
Allow DS components to implement ServiceFactory/PrototypeServiceFactory instead of service interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Thumbs.db
 .metadata/
 scrapbook.jpage
 /.recommenders/
+build/

--- a/org.osgi.test.cases.component/bnd.bnd
+++ b/org.osgi.test.cases.component/bnd.bnd
@@ -47,6 +47,7 @@ Import-Package: ${-signaturetest}, *
 	tb30.jar, \
 	tb31.jar, \
 	tb32.jar, \
+	tb33.jar, \
 	tbf1.jar
 	
 -signaturetest = \

--- a/org.osgi.test.cases.component/bnd/tb33.bnd
+++ b/org.osgi.test.cases.component/bnd/tb33.bnd
@@ -1,0 +1,5 @@
+Bundle-Version: 1
+-privatepackage: ${p}.tb33.*
+Service-Component: org/osgi/test/cases/component/tb33/impl/components.xml
+
+

--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/junit/DS15TestCase.java
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/junit/DS15TestCase.java
@@ -820,4 +820,78 @@ public class DS15TestCase {
 					.containsOnly("(osgi.condition.id=" + testName + ")");
 		});
 	}
+
+	/**
+	 * Tests that components can implement ServiceFactory<S> and 
+	 * PrototypeServiceFactory<S> instead of the service interface directly.
+	 * This tests the enhancement from issue #688.
+	 */
+	@Test
+	public void testServiceFactoryImplementation(
+			@InjectInstalledBundle("tb33.jar") Bundle tb33,
+			@InjectService(filter = "(test.name=singleton)", cardinality = 0) ServiceAware<org.osgi.test.cases.component.service.DataService> singletonService,
+			@InjectService(filter = "(test.name=bundle)", cardinality = 0) ServiceAware<org.osgi.test.cases.component.service.DataService> bundleService,
+			@InjectService(filter = "(test.name=prototype)", cardinality = 0) ServiceAware<org.osgi.test.cases.component.service.DataService> prototypeService) throws Exception {
+		
+		assertThat(tb33).as("tb33 bundle").isNotNull();
+		
+		// Start the bundle
+		tb33.start();
+		Sleep.sleep(SLEEP);
+		
+		// Test singleton-scoped ServiceFactory
+		assertThat(singletonService.getService())
+				.as("singleton DataService")
+				.isNotNull();
+		org.osgi.test.cases.component.service.DataService singleton1 = singletonService.getService();
+		String id1 = singleton1.getInstanceId();
+		assertThat(id1).as("singleton instance ID").isNotNull();
+		assertThat(singleton1.getBundleId()).as("singleton bundle ID")
+				.isEqualTo(context.getBundle().getBundleId());
+		
+		// Get the same service again - should be the same instance from the factory
+		org.osgi.test.cases.component.service.DataService singleton2 = singletonService.getService();
+		// Note: The service object might be different but should have same behavior
+		assertThat(singleton2).as("singleton DataService 2").isNotNull();
+		
+		// Test bundle-scoped ServiceFactory
+		assertThat(bundleService.getService())
+				.as("bundle DataService")
+				.isNotNull();
+		org.osgi.test.cases.component.service.DataService bundle1 = bundleService.getService();
+		String bundleId1 = bundle1.getInstanceId();
+		assertThat(bundleId1).as("bundle instance ID").isNotNull();
+		assertThat(bundle1.getBundleId()).as("bundle service bundle ID")
+				.isEqualTo(context.getBundle().getBundleId());
+		
+		// Test prototype-scoped PrototypeServiceFactory
+		ServiceReference<org.osgi.test.cases.component.service.DataService> prototypeRef = 
+				prototypeService.getServiceReference();
+		assertThat(prototypeRef).as("prototype service reference").isNotNull();
+		
+		org.osgi.framework.ServiceObjects<org.osgi.test.cases.component.service.DataService> serviceObjects = 
+				context.getServiceObjects(prototypeRef);
+		assertThat(serviceObjects).as("service objects").isNotNull();
+		
+		// Get multiple prototype instances
+		org.osgi.test.cases.component.service.DataService proto1 = serviceObjects.getService();
+		assertThat(proto1).as("prototype instance 1").isNotNull();
+		String protoId1 = proto1.getInstanceId();
+		assertThat(protoId1).as("prototype instance 1 ID").isNotNull();
+		
+		org.osgi.test.cases.component.service.DataService proto2 = serviceObjects.getService();
+		assertThat(proto2).as("prototype instance 2").isNotNull();
+		String protoId2 = proto2.getInstanceId();
+		assertThat(protoId2).as("prototype instance 2 ID").isNotNull();
+		
+		// The instance IDs should be different for prototype scope
+		assertThat(protoId1).as("prototype instances should be different")
+				.isNotEqualTo(protoId2);
+		
+		// Clean up
+		serviceObjects.ungetService(proto1);
+		serviceObjects.ungetService(proto2);
+		
+		tb33.stop();
+	}
 }

--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/service/DataService.java
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/service/DataService.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+
+package org.osgi.test.cases.component.service;
+
+/**
+ * Service interface for testing ServiceFactory implementation in components.
+ * This service provides data access functionality.
+ * 
+ * @author $Id$
+ */
+public interface DataService {
+	/**
+	 * Get a unique identifier for this service instance
+	 * @return unique identifier string
+	 */
+	String getInstanceId();
+	
+	/**
+	 * Get the bundle ID that requested this service
+	 * @return bundle ID
+	 */
+	long getBundleId();
+	
+	/**
+	 * Get some test data
+	 * @return test data string
+	 */
+	String getData();
+}

--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/impl/DataServiceFactoryComponent.java
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/impl/DataServiceFactoryComponent.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+
+package org.osgi.test.cases.component.tb33.impl;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceFactory;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.test.cases.component.service.DataService;
+
+/**
+ * Component that implements ServiceFactory<DataService> to provide
+ * DataService instances. This demonstrates the enhancement where a component
+ * can implement ServiceFactory instead of the service interface directly.
+ * 
+ * @author $Id$
+ */
+public class DataServiceFactoryComponent implements ServiceFactory<DataService> {
+	
+	private static final AtomicInteger instanceCounter = new AtomicInteger(0);
+	
+	@Override
+	public DataService getService(Bundle bundle, ServiceRegistration<DataService> registration) {
+		// Create a unique instance of the final class for each bundle
+		String instanceId = "instance-" + instanceCounter.incrementAndGet();
+		return new DataServiceImpl(instanceId, bundle.getBundleId());
+	}
+	
+	@Override
+	public void ungetService(Bundle bundle, ServiceRegistration<DataService> registration, DataService service) {
+		// Cleanup if needed
+		// In this test case, no cleanup is required
+	}
+}

--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/impl/DataServiceImpl.java
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/impl/DataServiceImpl.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+
+package org.osgi.test.cases.component.tb33.impl;
+
+import org.osgi.test.cases.component.service.DataService;
+
+/**
+ * Final class implementation of DataService that requires constructor arguments.
+ * This class cannot be directly instantiated by DS, demonstrating the need for
+ * ServiceFactory support.
+ * 
+ * @author $Id$
+ */
+public final class DataServiceImpl implements DataService {
+	private final String instanceId;
+	private final long bundleId;
+	
+	/**
+	 * Constructor requires parameters, which DS cannot provide directly
+	 */
+	public DataServiceImpl(String instanceId, long bundleId) {
+		this.instanceId = instanceId;
+		this.bundleId = bundleId;
+	}
+	
+	@Override
+	public String getInstanceId() {
+		return instanceId;
+	}
+	
+	@Override
+	public long getBundleId() {
+		return bundleId;
+	}
+	
+	@Override
+	public String getData() {
+		return "Data from instance " + instanceId + " for bundle " + bundleId;
+	}
+}

--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/impl/DataServicePrototypeFactoryComponent.java
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/impl/DataServicePrototypeFactoryComponent.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
+
+package org.osgi.test.cases.component.tb33.impl;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.PrototypeServiceFactory;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.test.cases.component.service.DataService;
+
+/**
+ * Component that implements PrototypeServiceFactory<DataService> to provide
+ * prototype-scoped DataService instances. This demonstrates the enhancement 
+ * where a component can implement PrototypeServiceFactory instead of the 
+ * service interface directly.
+ * 
+ * @author $Id$
+ */
+public class DataServicePrototypeFactoryComponent implements PrototypeServiceFactory<DataService> {
+	
+	private static final AtomicInteger instanceCounter = new AtomicInteger(0);
+	
+	@Override
+	public DataService getService(Bundle bundle, ServiceRegistration<DataService> registration) {
+		// Create a unique prototype instance for each request
+		String instanceId = "prototype-" + instanceCounter.incrementAndGet();
+		return new DataServiceImpl(instanceId, bundle.getBundleId());
+	}
+	
+	@Override
+	public void ungetService(Bundle bundle, ServiceRegistration<DataService> registration, DataService service) {
+		// Cleanup if needed
+		// In this test case, no cleanup is required
+	}
+}

--- a/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/impl/components.xml
+++ b/org.osgi.test.cases.component/src/org/osgi/test/cases/component/tb33/impl/components.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) Contributors to the Eclipse Foundation
+   
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+   
+        http://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+   
+    SPDX-License-Identifier: Apache-2.0 
+ -->
+
+<root>
+
+<!-- Component that implements ServiceFactory<DataService> with singleton scope -->
+<scr:component 
+	name="org.osgi.test.cases.component.tb33.DataServiceFactorySingleton"
+	xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0">
+	<implementation class="org.osgi.test.cases.component.tb33.impl.DataServiceFactoryComponent"/>
+	<service scope="singleton">
+		<provide interface="org.osgi.test.cases.component.service.DataService"/>
+	</service>
+	<property name="test.name" value="singleton"/>
+</scr:component>
+
+<!-- Component that implements ServiceFactory<DataService> with bundle scope -->
+<scr:component 
+	name="org.osgi.test.cases.component.tb33.DataServiceFactoryBundle"
+	xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0">
+	<implementation class="org.osgi.test.cases.component.tb33.impl.DataServiceFactoryComponent"/>
+	<service scope="bundle">
+		<provide interface="org.osgi.test.cases.component.service.DataService"/>
+	</service>
+	<property name="test.name" value="bundle"/>
+</scr:component>
+
+<!-- Component that implements PrototypeServiceFactory<DataService> with prototype scope -->
+<scr:component 
+	name="org.osgi.test.cases.component.tb33.DataServicePrototypeFactory"
+	xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0">
+	<implementation class="org.osgi.test.cases.component.tb33.impl.DataServicePrototypeFactoryComponent"/>
+	<service scope="prototype">
+		<provide interface="org.osgi.test.cases.component.service.DataService"/>
+	</service>
+	<property name="test.name" value="prototype"/>
+</scr:component>
+
+<!-- Component that implements ServiceFactory<DataService> with prototype scope 
+     This should work with bundle-scoped behavior -->
+<scr:component 
+	name="org.osgi.test.cases.component.tb33.DataServiceFactoryWithPrototypeScope"
+	xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0">
+	<implementation class="org.osgi.test.cases.component.tb33.impl.DataServiceFactoryComponent"/>
+	<service scope="prototype">
+		<provide interface="org.osgi.test.cases.component.service.DataService"/>
+	</service>
+	<property name="test.name" value="factory-prototype-scope"/>
+</scr:component>
+
+</root>

--- a/osgi.specs/docbook/112/service.component.xml
+++ b/osgi.specs/docbook/112/service.component.xml
@@ -2383,7 +2383,33 @@ public class MyComponent {
       the component instance.</para>
 
       <para>If the component description specifies a service, the class must
-      implement all interfaces that are provided by the service.</para>
+      either implement all interfaces that are provided by the service, or,
+      if the component provides exactly one service interface, the class may
+      implement <code>ServiceFactory&lt;S&gt;</code> or
+      <code>PrototypeServiceFactory&lt;S&gt;</code> where <code>S</code> is
+      the single service interface being provided. When a component
+      implements <code>ServiceFactory</code> or
+      <code>PrototypeServiceFactory</code>, SCR must register the component
+      instance directly with the OSGi Framework as a service factory, and the
+      Framework will call the component instance's <code>getService</code>
+      and <code>ungetService</code> methods as defined in the OSGi Core
+      specification. See <xref linkend="framework.service.serviceFactory"/>
+      and <xref linkend="framework.service.prototypeServiceFactory"/>. This
+      allows components to provide services whose implementation classes are
+      not directly instantiable by SCR, such as final classes requiring
+      constructor arguments, Java records, or classes with invisible
+      constructors that can only be instantiated via static factory
+      methods.</para>
+
+      <para>When a component implements <code>ServiceFactory&lt;S&gt;</code>
+      or <code>PrototypeServiceFactory&lt;S&gt;</code>, the
+      <code>scope</code> attribute specified in the component description is
+      ignored. The service scope is determined by the type of factory
+      implemented: <code>ServiceFactory</code> provides bundle scope
+      semantics, and <code>PrototypeServiceFactory</code> provides prototype
+      scope semantics, as defined in the OSGi Core specification. See <xref
+      linkend="framework.service.serviceFactory"/> and <xref
+      linkend="framework.service.prototypeServiceFactory"/>.</para>
     </section>
 
     <section xml:id="service.component-property.properties.elements">
@@ -2743,11 +2769,17 @@ public class FooImpl {
               specified Java class should be an interface rather than a class,
               however specifying a class is supported. The component
               implementation class must implement all the specified service
-              interfaces.</para><para>The Component annotation can specify the
-              provided services, if this element is not specified all directly
-              implemented interfaces on the component's type are defined as
-              service interfaces. Specifying an empty array indicates that no
-              service should be registered.</para></entry>
+              interfaces, or, if exactly one service interface is provided, the
+              component implementation class may implement
+              <code>ServiceFactory&lt;S&gt;</code> or
+              <code>PrototypeServiceFactory&lt;S&gt;</code> where
+              <code>S</code> is the single service interface. See <xref
+              linkend="service.component-implementation.element"/>.</para><para>The
+              Component annotation can specify the provided services, if this
+              element is not specified all directly implemented interfaces on
+              the component's type are defined as service interfaces. Specifying
+              an empty array indicates that no service should be
+              registered.</para></entry>
             </row>
           </tbody>
         </tgroup>
@@ -2766,6 +2798,36 @@ public class FooImpl {
 
       <programlisting>@Component
 public class Foo implements EventHandler { ... }</programlisting>
+
+      <para>Alternatively, a component can implement a service factory when
+      providing exactly one service. This is useful when the service
+      implementation class cannot be directly instantiated by SCR, such as
+      final classes, Java records, or classes with invisible
+      constructors:</para>
+
+      <programlisting>&lt;service&gt;
+    &lt;provide interface="com.example.DataService"/&gt;
+&lt;/service&gt;</programlisting>
+
+      <programlisting>@Component
+public class DataServiceFactoryComponent 
+    implements ServiceFactory&lt;DataService&gt; {
+    
+    @Override
+    public DataService getService(Bundle bundle, 
+                                   ServiceRegistration&lt;DataService&gt; reg) {
+        // Create and return the actual service object
+        // which may be a final class, record, etc.
+        return new DataServiceImpl(/* constructor args */);
+    }
+    
+    @Override
+    public void ungetService(Bundle bundle, 
+                             ServiceRegistration&lt;DataService&gt; reg,
+                             DataService service) {
+        // Clean up the service object if needed
+    }
+}</programlisting>
     </section>
 
     <section xml:id="service.component-reference.element">
@@ -3558,6 +3620,18 @@ public class FooImpl implements Foo {
       consist of the component properties as defined in <xref
       linkend="service.component-service.properties"/>.</para>
 
+      <para>When the component implementation class itself implements
+      <code>ServiceFactory&lt;S&gt;</code> or
+      <code>PrototypeServiceFactory&lt;S&gt;</code>, SCR must register the
+      component instance directly with the Framework when the component
+      configuration becomes satisfied. The Framework will then call the
+      component instance's <code>getService</code> and
+      <code>ungetService</code> methods according to the semantics defined in
+      the OSGi Core specification for <code>ServiceFactory</code> or
+      <code>PrototypeServiceFactory</code>. See <xref
+      linkend="framework.service.serviceFactory"/> and <xref
+      linkend="framework.service.prototypeServiceFactory"/>.</para>
+
       <para>The activation of a component configuration must be delayed until
       its service is requested. When the service is requested, if the service
       has the <code>scope</code> attribute set to <code>bundle</code>, SCR
@@ -3572,6 +3646,13 @@ public class FooImpl implements Foo {
       <xref
       linkend="org.osgi.service.component.ComponentContext.getUsingBundle--"
       xrefstyle="hyperlink"/> method on the Component Context.</para>
+
+      <para>When the component implementation class implements
+      <code>ServiceFactory&lt;S&gt;</code> or
+      <code>PrototypeServiceFactory&lt;S&gt;</code>, the <code>scope</code>
+      attribute is ignored, and the service registration behavior is
+      determined by the type of factory implemented as described in the OSGi
+      Core specification.</para>
 
       <para>The activation of delayed components is depicted in a state
       diagram in <xref linkend="i1462979"/>. Notice that multiple component


### PR DESCRIPTION
Update SCR specification to support ServiceFactory implementation

- Allow components to implement `ServiceFactory<S>` or `PrototypeServiceFactory<S>` when providing exactly one service
- Create new test bundle tb33 with `ServiceFactory` and `PrototypeServiceFactory` components

Fixes https://github.com/osgi/osgi/issues/688