### PR TITLE
Update RSA TCK to check event exception property

### DIFF
--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminExportTest.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminExportTest.java
@@ -527,11 +527,12 @@ public class RemoteServiceAdminExportTest extends DefaultTestBundleControl {
 
 			boolean exportFailed = false;
 			if ("org/osgi/service/remoteserviceadmin/EXPORT_REGISTRATION".equals(event.getTopic())) {
+				assertNull(event.getProperty("exception"));
 				assertNull(event.getProperty("cause"));
 				assertEquals(RemoteServiceAdminEvent.EXPORT_REGISTRATION, rsaevent.getType());
 			} else if ("org/osgi/service/remoteserviceadmin/EXPORT_ERROR".equals(event.getTopic())) {
 				exportFailed = true;
-				assertNotNull(event.getProperty("cause"));
+				assertNotNull(event.getProperty("exception"));
 				assertEquals(RemoteServiceAdminEvent.EXPORT_ERROR, rsaevent.getType());
 			}
 

--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminTest.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminTest.java
@@ -260,6 +260,7 @@ public class RemoteServiceAdminTest extends MultiFrameworkTestCase {
 			// check event type
 			String topic = event.getTopic();
 			assertEquals("org/osgi/service/remoteserviceadmin/IMPORT_REGISTRATION", topic);
+			assertNull("exception in event", event.getProperty("exception"));
 			assertNull("cause in event", event.getProperty("cause"));
 			assertEquals(RemoteServiceAdminEvent.IMPORT_REGISTRATION, rsaevent.getType());
 
@@ -296,6 +297,7 @@ public class RemoteServiceAdminTest extends MultiFrameworkTestCase {
 			assertEquals(0, eventHandler.getEventCount());
 			topic = event.getTopic();
 			assertEquals("org/osgi/service/remoteserviceadmin/IMPORT_REGISTRATION", topic);
+			assertNull("exception in event", event.getProperty("exception"));
 			assertNull("cause in event", event.getProperty("cause"));
 
 			// invoke service
@@ -362,6 +364,7 @@ public class RemoteServiceAdminTest extends MultiFrameworkTestCase {
 			assertEquals(0, eventHandler.getEventCount());
 			topic = event.getTopic();
 			assertEquals("122.4.8: wrong event topic", "org/osgi/service/remoteserviceadmin/IMPORT_UNREGISTRATION", topic);
+			assertNull("exception in event", event.getProperty("exception"));
 			assertNull("cause in event", event.getProperty("cause"));
 
 			//
@@ -393,6 +396,7 @@ public class RemoteServiceAdminTest extends MultiFrameworkTestCase {
 			assertEquals(0, eventHandler.getEventCount());
 			topic = event.getTopic();
 			assertEquals("122.4.8: wrong event topic", "org/osgi/service/remoteserviceadmin/IMPORT_UNREGISTRATION", topic);
+			assertNull("exception in event", event.getProperty("exception"));
 			assertNull("cause in event", event.getProperty("cause"));
 
 		} finally {

--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminUpdateTest.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminUpdateTest.java
@@ -140,6 +140,7 @@ public class RemoteServiceAdminUpdateTest extends MultiFrameworkTestCase {
 				// check event type
 				@SuppressWarnings("unused")
 				String topic = event.getTopic();
+				assertNull("exception in event", event.getProperty("exception"));
 				assertNull("cause in event", event.getProperty("cause"));
 				assertEquals(RemoteServiceAdminEvent.IMPORT_REGISTRATION,
 						rsaevent.getType());
@@ -222,6 +223,7 @@ public class RemoteServiceAdminUpdateTest extends MultiFrameworkTestCase {
 				// check event type
 				@SuppressWarnings("unused")
 				String topic = event.getTopic();
+				assertNull("exception in event", event.getProperty("exception"));
 				assertNull("cause in event", event.getProperty("cause"));
 				assertEquals(RemoteServiceAdminEvent.IMPORT_UPDATE,
 						rsaevent.getType());

--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/tb8/Activator.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/tb8/Activator.java
@@ -199,6 +199,7 @@ public class Activator implements BundleActivator, ModifiableService, B {
 				// check event type
 				@SuppressWarnings("unused")
 				String topic = event.getTopic();
+				assertNull("exception in event", event.getProperty("exception"));
 				assertNull("cause in event", event.getProperty("cause"));
 				assertEquals(
 						RemoteServiceAdminEvent.EXPORT_REGISTRATION,
@@ -275,6 +276,7 @@ public class Activator implements BundleActivator, ModifiableService, B {
 				// check event type
 				@SuppressWarnings("unused")
 				String topic = event.getTopic();
+				assertNull("exception in event", event.getProperty("exception"));
 				assertNull("cause in event", event.getProperty("cause"));
 				assertEquals(RemoteServiceAdminEvent.EXPORT_UPDATE,
 						rsaevent.getType());


### PR DESCRIPTION
In case of an error, the exception instance used to be set in the event property "cause", which was later renamed to "exception", however the tests weren't updated accordingly. This fix checks that both aren't set when there is no error, and "exception" is set when there is one.