### PR TITLE
Fix leaked services contaminating subsequent tests

### DIFF
--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminExportTest.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminExportTest.java
@@ -98,6 +98,7 @@ public class RemoteServiceAdminExportTest extends DefaultTestBundleControl {
 
 		super.tearDown();
 		ungetAllServices();
+		unregisterAllServices();
 
 		// wait until all remaining exports / imports are gone
 		remoteServiceAdmin = getService(RemoteServiceAdmin.class);
@@ -923,6 +924,7 @@ public class RemoteServiceAdminExportTest extends DefaultTestBundleControl {
 				},
 				                                                        service, dictionary);
 		assertNotNull(registration);
+		ServiceRegistration< ? > registration2 = null;
 
 		try {
 			//
@@ -1018,8 +1020,9 @@ public class RemoteServiceAdminExportTest extends DefaultTestBundleControl {
 
 			// register the service again
 			dictionary.remove(RemoteConstants.SERVICE_EXPORTED_CONFIGS);
-			registration = getContext().registerService(new String[]{A.class.getName(), B.class.getName()},
+			registration2 = getContext().registerService(new String[]{A.class.getName(), B.class.getName()},
 					service, dictionary);
+			assertNotNull(registration2);
 
 			// manipulate the config property
 			// by putting garbage in them
@@ -1031,7 +1034,7 @@ public class RemoteServiceAdminExportTest extends DefaultTestBundleControl {
 			// https://www.osgi.org/members/bugzilla/show_bug.cgi?id=2591
 			try {
 				exportRegistrations = remoteServiceAdmin.exportService(
-						registration.getReference(), properties);
+						registration2.getReference(), properties);
 				fail("Expected an illegal argumnet exception for garbage input");
 			} catch (IllegalArgumentException e) {
 				// as expected
@@ -1044,6 +1047,9 @@ public class RemoteServiceAdminExportTest extends DefaultTestBundleControl {
 		} finally {
 			try {
                 registration.unregister();
+				if (registration2 != null) {
+					registration2.unregister();
+				}
             } catch (Exception e) {
                 // We're just cleaning up here, so ignore the exception, if any
             }

--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminTest.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminTest.java
@@ -73,7 +73,16 @@ public class RemoteServiceAdminTest extends MultiFrameworkTestCase {
 		super.setUp();
 		timeout = getLongProperty("rsa.tck.timeout", 300000L);
 	}
-	
+
+	/**
+	 * @see org.osgi.test.cases.remoteserviceadmin.junit.MultiFrameworkTestCase#tearDown()
+	 */
+	@Override
+	protected void tearDown() throws Exception {
+		unregisterAllServices();
+		super.tearDown();
+	}
+
 	/**
 	 * @see org.osgi.test.cases.remoteserviceadmin.junit.MultiFrameworkTestCase#getConfiguration()
 	 */

--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminUpdateTest.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminUpdateTest.java
@@ -42,6 +42,15 @@ public class RemoteServiceAdminUpdateTest extends MultiFrameworkTestCase {
 	private static final String SYSTEM_PACKAGES_EXTRA = "org.osgi.test.cases.remoteserviceadmin.system.packages.extra";
 	private long m_timeout;
 
+	/**
+	 * @see org.osgi.test.cases.remoteserviceadmin.junit.MultiFrameworkTestCase#tearDown()
+	 */
+	@Override
+	protected void tearDown() throws Exception {
+		unregisterAllServices();
+		super.tearDown();
+	}
+
 	@Override
 	public Map<String, String> getConfiguration() {
 		Map<String, String> configuration = new HashMap<String, String>();


### PR DESCRIPTION
There are various tests that register services, mainly listeners used in testing generated events. However, some of them are never unregistered, so that they contaminate all subsequent tests. Such leaked listeners pile up to the point of seeing multiple listeners from previous tests still receiving events on later tests. All tests should be isolated, close all of their services and listeners, and run subsequent tests with a clean slate.