### PR TITLE
RSA TCK Listener deduplication and concurrency improvements

### DIFF
--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/common/TestEventHandler.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/common/TestEventHandler.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * SPDX-License-Identifier: Apache-2.0 
+ * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 package org.osgi.test.cases.remoteserviceadmin.common;
 
 import static junit.framework.TestCase.assertEquals;
 
+import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import org.osgi.framework.ServiceReference;
@@ -34,13 +34,11 @@ import org.osgi.service.remoteserviceadmin.RemoteServiceAdminEvent;
  * allows to request the events
  * */
 public class TestEventHandler implements EventHandler {
-	private final LinkedList<Event> eventlist = new LinkedList<Event>();
-	private final Semaphore sem = new Semaphore(0);
-
-	private final long m_timeout;
+	private final LinkedList<Event> events = new LinkedList<Event>();
+	private final long timeout;
 
 	public TestEventHandler(long timeout) {
-		m_timeout = timeout;
+		this.timeout = timeout;
 	}
 
 	/**
@@ -48,42 +46,32 @@ public class TestEventHandler implements EventHandler {
 	 */
 	@Override
 	public void handleEvent(Event event) {
-		// System.out
-		// .println("########################### TestEventHandler::handleEvent "
-		// + event.getTopic()
-		// + "  "
-		// + " ( "
-		// + Arrays.asList(event.getPropertyNames()) + "  )");
-
-		synchronized (eventlist) {
-			eventlist.add(event);
-			sem.release();
+		synchronized (events) {
+			events.add(event);
+			events.notifyAll();
 		}
-
 	}
 
 	public Event getNextEventForTopic(String... topics) {
-		if (topics.length == 0) {
-			throw new IllegalArgumentException(
-					"at least one topic must be provided");
-		}
 		try {
-			int waited = 0;
+			long end = System.currentTimeMillis() + timeout;
 			while (true) {
-				synchronized (eventlist) {
-					for (Event e : eventlist) {
+				synchronized (events) {
+					for (Iterator<Event> it = events.iterator(); it.hasNext(); ) {
+						Event event = it.next();
 						for (String topic : topics) {
-							if (topic.equals(e.getTopic())) {
-								eventlist.remove(e);
-								return e;
+							if (topic.equals(event.getTopic())) {
+								it.remove();
+								return event;
 							}
 						}
 					}
+					long remaining = end - System.currentTimeMillis();
+					if (remaining <= 0) {
+						return null;
+					}
+					events.wait(remaining);
 				}
-				sem.tryAcquire(m_timeout / 10, TimeUnit.MILLISECONDS);
-				++waited;
-				if (waited >= 10)
-					return null;
 			}
 		} catch (InterruptedException e1) {
 			return null;
@@ -112,8 +100,8 @@ public class TestEventHandler implements EventHandler {
 	}
 
 	public int getEventCount() {
-		synchronized (eventlist) {
-			return eventlist.size();
+		synchronized (events) {
+			return events.size();
 		}
 	}
 }

--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/common/TestRemoteServiceAdminListener.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/common/TestRemoteServiceAdminListener.java
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * SPDX-License-Identifier: Apache-2.0 
+ * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 package org.osgi.test.cases.remoteserviceadmin.common;
 
 import java.util.LinkedList;
-import java.util.NoSuchElementException;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
+import java.util.Queue;
 
 import org.osgi.service.remoteserviceadmin.RemoteServiceAdminEvent;
 import org.osgi.service.remoteserviceadmin.RemoteServiceAdminListener;
@@ -28,15 +26,14 @@ import org.osgi.service.remoteserviceadmin.RemoteServiceAdminListener;
 /**
  * RemoteServiceAdminListener implementation, which collects and returns the
  * received events in order.
- * 
+ *
  * @author <a href="mailto:tdiekman@tibco.com">Tim Diekmann</a>
- * 
+ *
  */
 public class TestRemoteServiceAdminListener implements
 		RemoteServiceAdminListener {
-	private LinkedList<RemoteServiceAdminEvent> eventlist = new LinkedList<RemoteServiceAdminEvent>();
-	private Semaphore sem = new Semaphore(0);
-	private long timeout;
+	private final Queue<RemoteServiceAdminEvent> events = new LinkedList<RemoteServiceAdminEvent>();
+	private final long timeout;
 
 	public TestRemoteServiceAdminListener(long timeout) {
 		this.timeout = timeout;
@@ -47,25 +44,36 @@ public class TestRemoteServiceAdminListener implements
 	 */
 	@Override
 	public void remoteAdminEvent(final RemoteServiceAdminEvent event) {
-		eventlist.add(event);
-		sem.release();
+		synchronized (events) {
+			events.offer(event);
+			events.notify();
+		}
 	}
 
 	public RemoteServiceAdminEvent getNextEvent() {
 		try {
-			sem.tryAcquire(timeout, TimeUnit.MILLISECONDS);
+			long end = System.currentTimeMillis() + timeout;
+			while (true) {
+				synchronized (events) {
+					RemoteServiceAdminEvent event = events.poll();
+					if (event != null) {
+						return event;
+					}
+					long remaining = end - System.currentTimeMillis();
+					if (remaining <= 0) {
+						return null;
+					}
+					events.wait(remaining);
+				}
+			}
 		} catch (InterruptedException e1) {
-			return null;
-		}
-
-		try {
-			return eventlist.removeFirst();
-		} catch (NoSuchElementException e) {
 			return null;
 		}
 	}
 
 	public int getEventCount() {
-		return eventlist.size();
+		synchronized (events) {
+			return events.size();
+		}
 	}
 }

--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminExportTest.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminExportTest.java
@@ -29,10 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 import java.util.Arrays;
 import org.osgi.framework.ServiceReference;
@@ -51,6 +48,7 @@ import org.osgi.test.cases.remoteserviceadmin.common.A;
 import org.osgi.test.cases.remoteserviceadmin.common.B;
 import org.osgi.test.cases.remoteserviceadmin.common.RemoteServiceConstants;
 import org.osgi.test.cases.remoteserviceadmin.common.TestEventHandler;
+import org.osgi.test.cases.remoteserviceadmin.common.TestRemoteServiceAdminListener;
 import org.osgi.test.support.compatibility.DefaultTestBundleControl;
 import org.osgi.test.support.sleep.Sleep;
 import org.osgi.util.tracker.ServiceTracker;
@@ -321,7 +319,7 @@ public class RemoteServiceAdminExportTest extends DefaultTestBundleControl {
 			// register a RemoteServiceAdminListener to receive the export
 			// notification
 			//
-			TestRemoteServiceAdminListener remoteServiceAdminListener = new TestRemoteServiceAdminListener();
+			TestRemoteServiceAdminListener remoteServiceAdminListener = new TestRemoteServiceAdminListener(timeout);
 			registerService(RemoteServiceAdminListener.class.getName(), remoteServiceAdminListener, null);
 
 			//
@@ -774,7 +772,7 @@ public class RemoteServiceAdminExportTest extends DefaultTestBundleControl {
 			// register a RemoteServiceAdminListener to receive the export
 			// notification
 			//
-			TestRemoteServiceAdminListener remoteServiceAdminListener = new TestRemoteServiceAdminListener();
+			TestRemoteServiceAdminListener remoteServiceAdminListener = new TestRemoteServiceAdminListener(timeout);
 			registerService(RemoteServiceAdminListener.class.getName(), remoteServiceAdminListener, null);
 
 			//
@@ -929,7 +927,7 @@ public class RemoteServiceAdminExportTest extends DefaultTestBundleControl {
 			// register a RemoteServiceAdminListener to receive the export
 			// notification
 			//
-			TestRemoteServiceAdminListener remoteServiceAdminListener = new TestRemoteServiceAdminListener();
+			TestRemoteServiceAdminListener remoteServiceAdminListener = new TestRemoteServiceAdminListener(timeout);
 			registerService(RemoteServiceAdminListener.class.getName(), remoteServiceAdminListener, null);
 
 			//
@@ -1283,42 +1281,6 @@ public class RemoteServiceAdminExportTest extends DefaultTestBundleControl {
 			return "this is B";
 		}
 
-	}
-
-	/**
-	 * RemoteServiceAdminListener implementation, which collects and
-	 * returns the received events in order.
-	 *
-	 * @author <a href="mailto:tdiekman@tibco.com">Tim Diekmann</a>
-	 *
-	 */
-	class TestRemoteServiceAdminListener implements RemoteServiceAdminListener {
-		private final LinkedList<RemoteServiceAdminEvent> eventlist = new LinkedList<RemoteServiceAdminEvent>();
-		private final Semaphore sem = new Semaphore(0);
-
-		@Override
-		public void remoteAdminEvent(final RemoteServiceAdminEvent event) {
-			eventlist.add(event);
-			sem.release();
-		}
-
-		RemoteServiceAdminEvent getNextEvent() {
-			try {
-				sem.tryAcquire(timeout, TimeUnit.MILLISECONDS);
-			} catch (InterruptedException e1) {
-				return null;
-			}
-
-			try {
-				return eventlist.removeFirst();
-			} catch (NoSuchElementException e) {
-				return null;
-			}
-		}
-
-		int getEventCount() {
-			return eventlist.size();
-		}
 	}
 
 }

--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminTest.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/junit/RemoteServiceAdminTest.java
@@ -23,14 +23,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Hashtable;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.StringTokenizer;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -50,6 +46,7 @@ import org.osgi.service.remoteserviceadmin.RemoteServiceAdminListener;
 import org.osgi.test.cases.remoteserviceadmin.common.A;
 import org.osgi.test.cases.remoteserviceadmin.common.B;
 import org.osgi.test.cases.remoteserviceadmin.common.TestEventHandler;
+import org.osgi.test.cases.remoteserviceadmin.common.TestRemoteServiceAdminListener;
 import org.osgi.test.cases.remoteserviceadmin.common.Utils;
 
 /**
@@ -158,7 +155,7 @@ public class RemoteServiceAdminTest extends MultiFrameworkTestCase {
 			// register a RemoteServiceAdminListener to receive the import
 			// notification
 			//
-			TestRemoteServiceAdminListener remoteServiceAdminListener = new TestRemoteServiceAdminListener();
+			TestRemoteServiceAdminListener remoteServiceAdminListener = new TestRemoteServiceAdminListener(timeout);
 			registerService(RemoteServiceAdminListener.class.getName(), remoteServiceAdminListener, null);
 
 			//
@@ -537,48 +534,7 @@ public class RemoteServiceAdminTest extends MultiFrameworkTestCase {
 		public String getB() {
 			return "this is B";
 		}
-		
+
 	}
-
-	/**
-	 * RemoteServiceAdminListener implementation, which collects and returns the
-	 * received events in order.
-	 * 
-	 * @author <a href="mailto:tdiekman@tibco.com">Tim Diekmann</a>
-	 * 
-	 */
-	class TestRemoteServiceAdminListener implements RemoteServiceAdminListener {
-		private final LinkedList<RemoteServiceAdminEvent> eventlist = new LinkedList<RemoteServiceAdminEvent>();
-		private final Semaphore sem = new Semaphore(0);
-
-		/**
-		 * @see org.osgi.service.remoteserviceadmin.RemoteServiceAdminListener#remoteAdminEvent(org.osgi.service.remoteserviceadmin.RemoteServiceAdminEvent)
-		 */
-		@Override
-		public void remoteAdminEvent(final RemoteServiceAdminEvent event) {
-			eventlist.add(event);
-			sem.release();
-		}
-
-		RemoteServiceAdminEvent getNextEvent() {
-			try {
-				sem.tryAcquire(timeout, TimeUnit.MILLISECONDS);
-			} catch (InterruptedException e1) {
-				return null;
-			}
-
-			try {
-				return eventlist.removeFirst();
-			} catch (NoSuchElementException e) {
-				return null;
-			}
-		}
-
-		int getEventCount() {
-			return eventlist.size();
-		}
-	}
-	
-
 
 }


### PR DESCRIPTION
Improves the event listeners used in the RSA TCK tests:
- Classes were duplicated in each test, fixed by reusing the same common class.
- Concurrency handling seems off: it uses a semaphore for synchronization even though there is no need for managing a number of permits. Further, it seems to get this wrong - adding a permit when adding an event, but then removing anywhere between 0 and 10 permits when an event is removed, so it is unclear what this is trying to achieve. Also, there are multiple waits for timeout/10, possibly an attempt to overcome a bug in concurrency handling here but unclear.

  Another listener just uses plain LinkedList with no synchronization at all.

  This is fixed by reimplementing the common listeners using simple synchronized/wait/notify with more precise control over the concurrency management to make it thread safe with straightforward logic.