### PR TITLE
Fix listener race condition at startup

### DIFF
--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/common/MatchedServiceTracker.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/common/MatchedServiceTracker.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+package org.osgi.test.cases.remoteserviceadmin.common;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Filter;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+
+/**
+ * A {@link ServiceTracker} that keeps track of services that match a given predicate.
+ *
+ * @param <S> the service type
+ */
+public class MatchedServiceTracker<S> extends ServiceTracker<S, S> {
+
+	private final Predicate<ServiceReference<S>> predicate;
+	private final Set<S> matching = new HashSet<>();
+	private final BiConsumer<ServiceReference<S>, S> action;
+
+	public MatchedServiceTracker(BundleContext context, Filter filter,
+			 Predicate<ServiceReference<S>> predicate, BiConsumer<ServiceReference<S>, S> action) {
+		super(context, filter, null);
+		this.predicate = predicate;
+		this.action = action;
+	}
+
+	@Override
+	public S addingService(ServiceReference<S> ref) {
+		S service = super.addingService(ref);
+		synchronized (matching) {
+			if (predicate.test(ref) && matching.add(service)) {
+				if (action != null) {
+					action.accept(ref, service);
+				}
+				matching.notifyAll();
+			}
+		}
+		return service;
+	}
+
+	@Override
+	public void modifiedService(ServiceReference<S> ref, S service) {
+		synchronized (matching) {
+			if (!predicate.test(ref)) {
+				matching.remove(service);
+			} else if (matching.add(service)) {
+				if (action != null) {
+					action.accept(ref, service);
+				}
+				matching.notifyAll();
+			}
+		}
+	}
+
+	@Override
+	public void removedService(ServiceReference<S> ref, S service) {
+		synchronized (matching) {
+			matching.remove(service);
+		}
+		super.removedService(ref, service);
+	}
+
+	public Set<S> getMatching() {
+		synchronized (matching) {
+			return new HashSet<>(matching);
+		}
+	}
+
+	public S awaitMatch(long timeout, TimeUnit unit) throws InterruptedException {
+		long deadline = System.currentTimeMillis() + unit.toMillis(timeout);
+		synchronized (matching) {
+			while (matching.isEmpty()) {
+				long remaining = deadline - System.currentTimeMillis();
+				if (remaining <= 0)
+					return null;
+				matching.wait(remaining);
+			}
+			return matching.iterator().next();
+		}
+	}
+}

--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/common/Utils.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/common/Utils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * SPDX-License-Identifier: Apache-2.0 
+ * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 package org.osgi.test.cases.remoteserviceadmin.common;
 
@@ -31,9 +31,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.StringTokenizer;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.remoteserviceadmin.EndpointDescription;
+import org.osgi.service.remoteserviceadmin.EndpointEventListener;
 import org.osgi.test.support.OSGiTestCase;
 
 public class Utils {
@@ -48,7 +54,7 @@ public class Utils {
 	 * @param scopeobj
 	 * @param description
 	 * @return
-	 * 
+	 *
 	 * @author <a href="mailto:tdiekman@tibco.com">Tim Diekmann</a>
 	 */
 	public static String isInterested(Object scopeobj,
@@ -81,7 +87,7 @@ public class Utils {
 		}
 		return null;
 	}
-	
+
 	/**
 	 * @param testCase
 	 * @return EndpointDescription reconstructed from a HEX string passed by the
@@ -133,11 +139,11 @@ public class Utils {
 
 		return new EndpointDescription(props);
 	}
-	
+
 	/**
 	 * Write the contents of the EndpointDescription into System properties for
 	 * the parent framework to read and then import.
-	 * 
+	 *
 	 * @param ed
 	 * @throws IOException
 	 */
@@ -222,5 +228,43 @@ public class Utils {
 		return properties;
 	}
 
+	/**
+	 * Notify endpoint listeners of the given class whose scope matches
+	 * the given endpoint by invoking the given action with it. If no
+	 * listener is available that matches the scope, waits until the given
+	 * timeout for one to be registered and then invokes it.
+	 *
+	 * @param context the bundle context
+	 * @param clazz the listener class
+	 * @param endpoint the endpoint to match against the scopes
+	 * @param timeout the max time to wait for a matching listener
+	 * @param action the action to invoke on matched listeners
+	 *        (given the matched filter and listener instance)
+	 * @return true if at least one listener matched, false if none matched
+	 * @param <S> the listener type
+	 * @throws InvalidSyntaxException if an error occurred while preparing the registration filter
+	 * @throws InterruptedException if the thread is interrupted while waiting
+	 */
+	public static <S> boolean notifyMatchingListeners(BundleContext context, Class<S> clazz,
+			EndpointDescription endpoint, long timeout,
+			BiConsumer<String, S> action) throws InvalidSyntaxException, InterruptedException {
+		String filter = "(&(" + Constants.OBJECTCLASS + "=" + clazz.getName()
+			+ ")(" + EndpointEventListener.ENDPOINT_LISTENER_SCOPE + "=*))";
+		MatchedServiceTracker<S> tracker = new MatchedServiceTracker<>(context, FrameworkUtil.createFilter(filter),
+			reference -> {
+				Object scope = reference.getProperty(EndpointEventListener.ENDPOINT_LISTENER_SCOPE);
+				return isInterested(scope, endpoint) != null;
+			}, (reference, listener) -> {
+			Object scope = reference.getProperty(EndpointEventListener.ENDPOINT_LISTENER_SCOPE);
+			String matchedFilter = isInterested(scope, endpoint);
+			action.accept(matchedFilter, listener);
+		});
+		tracker.open();
+		try {
+			return tracker.awaitMatch(timeout, TimeUnit.MILLISECONDS) != null;
+		} finally {
+			tracker.close();
+		}
+	}
 
 }

--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/tb1/Activator.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/tb1/Activator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * SPDX-License-Identifier: Apache-2.0 
+ * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 package org.osgi.test.cases.remoteserviceadmin.tb1;
 
@@ -24,22 +24,17 @@ import static junit.framework.TestCase.assertTrue;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.remoteserviceadmin.EndpointDescription;
+import org.osgi.service.remoteserviceadmin.EndpointListener;
 import org.osgi.service.remoteserviceadmin.RemoteConstants;
 import org.osgi.test.cases.remoteserviceadmin.common.A;
 import org.osgi.test.cases.remoteserviceadmin.common.B;
 import org.osgi.test.cases.remoteserviceadmin.common.RemoteServiceConstants;
 import org.osgi.test.cases.remoteserviceadmin.common.Utils;
-import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * @author <a href="mailto:tdiekman@tibco.com">Tim Diekmann</a>
@@ -51,25 +46,20 @@ public class Activator implements BundleActivator, A, B {
 	BundleContext       context;
 	EndpointDescription endpoint;
 
-	Semaphore																													semaphore	= new Semaphore(
-			0);
-
-	ServiceTracker<org.osgi.service.remoteserviceadmin.EndpointListener,org.osgi.service.remoteserviceadmin.EndpointListener>	tracker;
-
 	/**
 	 * @see org.osgi.framework.BundleActivator#start(org.osgi.framework.BundleContext)
 	 */
 	@Override
 	public void start(BundleContext context) throws Exception {
 		this.context = context;
-		
+
 		Hashtable<String, String> dictionary = new Hashtable<String, String>();
 		dictionary.put("mykey", "will be overridden");
 		dictionary.put("myprop", "myvalue");
 		dictionary.put(RemoteServiceConstants.SERVICE_EXPORTED_INTERFACES, A.class.getName());
 
 		registration = context.registerService(new String[]{A.class.getName()}, this, dictionary);
-		
+
 		test();
 	}
 
@@ -79,11 +69,8 @@ public class Activator implements BundleActivator, A, B {
 	@Override
 	public void stop(BundleContext context) throws Exception {
 		registration.unregister();
-		
-		stoptest();
 
-		if (tracker != null)
-			tracker.close();
+		stoptest();
 	}
 
 	/**
@@ -101,7 +88,7 @@ public class Activator implements BundleActivator, A, B {
 	public String getB() {
 		return "this is B";
 	}
-	
+
 	private void test() throws Exception {
 		//
 		// create an EndpointDescription
@@ -116,82 +103,34 @@ public class Activator implements BundleActivator, A, B {
 		properties.put(RemoteConstants.ENDPOINT_ID, "someURI"); // mandatory
 		properties.put(RemoteConstants.SERVICE_IMPORTED_CONFIGS, "A"); // mandatory
 		endpoint = new EndpointDescription(registration.getReference(), properties);
-		
+
 		assertNotNull(endpoint);
 		assertEquals("Endpoint properties are supposed to trump service properties", "has been overridden", endpoint.getProperties().get("mykey"));
 
-		// 
+		//
 		// find the EndpointListeners and call them with the endpoint description
 		//
-		String filter = "(&(" + Constants.OBJECTCLASS + "="
-				+ org.osgi.service.remoteserviceadmin.EndpointListener.class
-						.getName()
-				+ ")("
-				+ org.osgi.service.remoteserviceadmin.EndpointListener.ENDPOINT_LISTENER_SCOPE
-				+ "=*))"; // see
-																		// 122.6.1
+		String timeoutString = context.getProperty("rsa.tck.timeout");
+		long timeout = timeoutString != null ? Long.parseLong(timeoutString) : 30000;
+		boolean notified = Utils.notifyMatchingListeners(context, EndpointListener.class, endpoint, timeout,
+			(matchedFilter, listener) -> listener.endpointAdded(endpoint, matchedFilter));
 
-		tracker = new ServiceTracker<org.osgi.service.remoteserviceadmin.EndpointListener,org.osgi.service.remoteserviceadmin.EndpointListener>(
-				context, FrameworkUtil.createFilter(filter), null) {
-
-			@Override
-			public org.osgi.service.remoteserviceadmin.EndpointListener addingService(
-					ServiceReference<org.osgi.service.remoteserviceadmin.EndpointListener> reference) {
-				org.osgi.service.remoteserviceadmin.EndpointListener listener = super.addingService(
-						reference);
-
-				Object scope = reference
-						.getProperty(
-								org.osgi.service.remoteserviceadmin.EndpointListener.ENDPOINT_LISTENER_SCOPE);
-
-				String matchedFilter = Utils.isInterested(scope, endpoint);
-
-				if (matchedFilter != null) {
-					listener.endpointAdded(endpoint, matchedFilter);
-					semaphore.release();
-				}
-
-				return listener;
-			}
-		};
-
-		tracker.open();
-		
-		String timeout = context.getProperty("rsa.tck.timeout");
-		
-		assertTrue("no interested EndpointListener found", semaphore
-				.tryAcquire(Long.parseLong(timeout != null ? timeout
-						: "30000"), TimeUnit.MILLISECONDS));
+		assertTrue("no interested EndpointListener found", notified);
 	}
 
 	/**
-	 * 
+	 *
 	 */
 	private void stoptest() throws Exception {
-		// 
+		//
 		// find the EndpointListeners and call them with the endpoint description
 		//
-		ServiceReference<org.osgi.service.remoteserviceadmin.EndpointListener>[] listeners = tracker
-				.getServiceReferences();
-		assertNotNull("no EndpointListeners found", listeners);
-		
-		boolean foundListener = false;
-		for (ServiceReference<org.osgi.service.remoteserviceadmin.EndpointListener> sr : listeners) {
-			org.osgi.service.remoteserviceadmin.EndpointListener listener = context
-					.getService(sr);
-			Object scope = sr.getProperty(
-					org.osgi.service.remoteserviceadmin.EndpointListener.ENDPOINT_LISTENER_SCOPE);
-			
-			String matchedFilter = Utils.isInterested(scope, endpoint);
-			
-			if (matchedFilter != null) {
-				foundListener = true;
-				listener.endpointRemoved(endpoint, matchedFilter);
-			}
-		}
-		assertTrue("no interested EndpointListener found", foundListener);
+		boolean notified = Utils.notifyMatchingListeners(context, EndpointListener.class, endpoint, 0,
+			(matchedFilter, listener) -> listener.endpointRemoved(endpoint, matchedFilter));
+
+		assertTrue("no interested EndpointListener found", notified);
 	}
-	
+
 
 
 }

--- a/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/tb7/Activator.java
+++ b/org.osgi.test.cases.remoteserviceadmin/src/org/osgi/test/cases/remoteserviceadmin/tb7/Activator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * SPDX-License-Identifier: Apache-2.0 
+ * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 
 package org.osgi.test.cases.remoteserviceadmin.tb7;
@@ -24,38 +24,30 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
-import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.remoteserviceadmin.EndpointDescription;
-import org.osgi.service.remoteserviceadmin.EndpointEvent;
-import org.osgi.service.remoteserviceadmin.EndpointEventListener;
-import org.osgi.service.remoteserviceadmin.RemoteConstants;
+import org.osgi.service.remoteserviceadmin.*;
 import org.osgi.test.cases.remoteserviceadmin.common.B;
 import org.osgi.test.cases.remoteserviceadmin.common.ModifiableService;
 import org.osgi.test.cases.remoteserviceadmin.common.RemoteServiceConstants;
 import org.osgi.test.cases.remoteserviceadmin.common.Utils;
-import org.osgi.util.tracker.ServiceTracker;
 
 /**
- * 
+ *
  * Test bundle that registers a service to be exported and manually notifies any
  * discovery implementation that it should publish an endpoint for this service.
  * The bundle is very similar to tb1 but uses the RSA 1.1 EndpointEventListener
  * instead of the deprecated EndpointListener.
- * 
+ *
  * The bundle further provides an implementation of the ModifiableService
  * allowing to remotely change the service registration to cause a service
  * modified event.
- * 
+ *
  * @author <a href="mailto:marc@marc-schaaf.de">Marc Schaaf</a>
- * 
+ *
  */
 public class Activator implements BundleActivator, ModifiableService, B {
 
@@ -66,8 +58,6 @@ public class Activator implements BundleActivator, ModifiableService, B {
 
 	Semaphore													semaphore	= new Semaphore(
 			0);
-
-	ServiceTracker<EndpointEventListener, EndpointEventListener> tracker;
 
 	@Override
 	public void start(BundleContext context) throws Exception {
@@ -136,9 +126,6 @@ public class Activator implements BundleActivator, ModifiableService, B {
 	public void stop(BundleContext context) throws Exception {
 		registration.unregister();
 		stoptest();
-		if (tracker != null) {
-			tracker.close();
-		}
 	}
 
 	@Override
@@ -198,69 +185,16 @@ public class Activator implements BundleActivator, ModifiableService, B {
 
 		// FIXME: should I also filter for framework UUID == my UUID as
 		// suggested in 122.6.1?
-		if (tracker == null) {
-			createTracker(context, endpointEvent);
-		} else {
-			ServiceReference<EndpointEventListener>[] refs = tracker
-					.getServiceReferences();
-			if (refs != null) {
-				for (ServiceReference<EndpointEventListener> ref : refs) {
-					sendEventIfMatches(endpointEvent, context, ref);
-				}
-			}
-		}
 
-		String timeout = context.getProperty("rsa.tck.timeout");
-
+		String timeoutString = context.getProperty("rsa.tck.timeout");
+		long timeout = timeoutString != null ? Long.parseLong(timeoutString) : 30000;
 		try {
-			assertTrue("no interested EndpointEventListener found",
-					semaphore.tryAcquire(Long
-							.parseLong(timeout != null ? timeout : "30000"),
-							TimeUnit.MILLISECONDS));
+			boolean notified = Utils.notifyMatchingListeners(context, EndpointEventListener.class, endpoint, timeout,
+				(matchedFilter, listener) -> listener.endpointChanged(endpointEvent, matchedFilter));
+			assertTrue("no interested EndpointEventListener found", notified);
 		} catch (InterruptedException e) {
 			throw new RuntimeException(e);
 		}
-	}
-
-	EndpointEventListener sendEventIfMatches(
-			final EndpointEvent endpointEvent, BundleContext context,
-			ServiceReference<EndpointEventListener> reference) {
-		EndpointEventListener listener = context.getService(reference);
-
-		Object scope = reference
-				.getProperty(EndpointEventListener.ENDPOINT_LISTENER_SCOPE);
-
-		String matchedFilter = Utils.isInterested(scope, endpoint);
-
-		if (matchedFilter != null) {
-			listener.endpointChanged(endpointEvent, matchedFilter);
-			System.out
-					.println("TestBundle7: ******************** Propagated EndpointChanged Event to endpointEventListener: "
-							+ listener + " <<  " + endpointEvent.getType());
-			semaphore.release();
-		}
-
-		return listener;
-	}
-
-	private void createTracker(final BundleContext context,
-			final EndpointEvent endpointEvent) throws InvalidSyntaxException {
-		String filter = "(&(" + Constants.OBJECTCLASS + "="
-				+ EndpointEventListener.class.getName() + ")("
-				+ EndpointEventListener.ENDPOINT_LISTENER_SCOPE + "=*))"; // see
-																			// 122.6.1
-
-		tracker = new ServiceTracker<EndpointEventListener, EndpointEventListener>(
-				context, FrameworkUtil.createFilter(filter), null) {
-
-			@Override
-			public EndpointEventListener addingService(
-					ServiceReference<EndpointEventListener> reference) {
-				return sendEventIfMatches(endpointEvent, context, reference);
-			}
-		};
-
-		tracker.open();
 	}
 
 }


### PR DESCRIPTION
This is a suggestion for solving https://github.com/osgi/osgi/issues/946.
It also deduplicates nearly identical code between tb1 and tb7.
It may need some tweaking, but is the general idea viable?

In general I'd like to point out that when the TCK test suite impersonates a component in order to test the interaction with other components (such as sending or receiving events), it should itself comply with the spec requirements, otherwise it may incorrectly fail a compliant implementation because the test itself doesn't play by the rules. This issue is one example of that, where it doesn't properly handle scope update events, as are other tests that e.g. check for a specific number of events even though the spec explicitly allows duplicate events and requires idempotency etc.