### PR TITLE
ServiceLoader TCK: skip mediator stop/restart check in testAutoRegister when mediator is the system bundle

### DIFF
--- a/org.osgi.test.cases.serviceloader/src/org/osgi/test/cases/serviceloader/junit/ServiceLoaderTest.java
+++ b/org.osgi.test.cases.serviceloader/src/org/osgi/test/cases/serviceloader/junit/ServiceLoaderTest.java
@@ -18,6 +18,8 @@
 
 package org.osgi.test.cases.serviceloader.junit;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.util.List;
 
 import org.osgi.framework.Bundle;
@@ -206,6 +208,15 @@ public class ServiceLoaderTest extends OSGiTestCase {
 			assertEquals("public property must be registered with the service", "TCK", refs[1].getProperty("provider"));
 			assertNull("private properties must not be registered with the service", refs[0].getProperty(".hint"));
 			assertNull("private properties must not be registered with the service", refs[1].getProperty(".hint"));
+
+			// If the mediator is implemented as a framework extension bundle
+			// (Fragment-Host: ...;extension:=framework), its osgi.extender
+			// capability is attributed to the system bundle (id 0) in the wiring
+			// graph. Stopping the system bundle stops the whole framework -
+			// including the test engine running inside it - so this part of the
+			// test cannot be exercised for such mediator implementations.
+			assumeTrue("mediator bundle is the system bundle; stopping it would stop the running test engine",
+					mediatorBundle.getBundleId() != 0);
 
 			mediatorBundle.stop();
 			refs = mediatorBundle.getRegisteredServices();


### PR DESCRIPTION
## Problem

`ServiceLoaderTest#testAutoRegister` looks up the bundle that provides
the `osgi.extender` capability the tested provider bundle wires to,
and calls `mediatorBundle.stop()` to verify that its registered
services get unregistered, then relies on the `finally` block to
restart it.

This assumes the mediator is always a regular bundle with an
independent lifecycle. However, the ServiceLoader Mediator
specification (134) also permits implementing the mediator as a
**framework extension bundle**
(`Fragment-Host: ...;extension:=framework`). In that case, per the
OSGi wiring model, a fragment's capabilities are attributed to its
**host** bundle - so `wire.getProvider().getBundle()` resolves to the
**system bundle (id 0)**.

Calling `.stop()` on the system bundle stops the whole framework. When
the TCK test itself runs *inside* that same framework (e.g. via a
self-hosted bnd/aQute JUnit-platform test engine, as used by Tycho's
`bnd-test`/`tck` tooling), this also tears down the running test
engine, so the test run fails/hangs instead of producing a meaningful
pass/fail result about mediator behavior.

We hit this concretely while conformance-testing
[Eclipse Equinox's Service Loader Mediator implementation](https://github.com/eclipse-equinox/equinox/tree/master/bundles/org.eclipse.equinox.spi),
which implements the mediator as a framework extension for integration
reasons specific to that framework.

## Fix

Guard just the mediator-stop/restart portion of `testAutoRegister`
with `Assume.assumeTrue(mediatorBundle.getBundleId() != 0, ...)`, so
it is skipped when the mediator is attributed to the system bundle.
All other assertions in the test (provider install, auto-registration,
service properties, property visibility, provider bundle restart)
are unaffected and still run normally - only the truly
implementation-incompatible destructive assertion is skipped.

This uses the same `org.junit.Assume` pattern already used elsewhere
in this test suite family, e.g.
`org.osgi.test.cases.jpa.junit.JPATestCase#testPersistenceProviderRegistration`,
so no `bnd.bnd`/buildpath changes are required.

## Alternatives considered

- Requiring all mediator implementations to be regular bundles: not
  reasonable, the ServiceLoader Mediator spec does not mandate this,
  and framework-extension-based implementations are a legitimate,
  spec-compliant approach.
- Removing/weakening the stop/restart assertion entirely: rejected,
  since it verifies a real, spec-mandated extender contract (cleanup
  on stop, re-registration on restart) that remains fully meaningful
  and testable for mediator implementations that are regular bundles.